### PR TITLE
Merge devices from the same bus

### DIFF
--- a/src/server/pages.rs
+++ b/src/server/pages.rs
@@ -25,6 +25,7 @@ use std::io::prelude::*;
 pub struct ApiVideoSource {
     name: String,
     source: String,
+    source_type: VideoSourceType,
     formats: Vec<Format>,
     controls: Vec<Control>,
 }
@@ -110,22 +111,25 @@ pub async fn v4l() -> Json<Vec<ApiVideoSource>> {
     let cameras = video_source::cameras_available();
     let cameras: Vec<ApiVideoSource> = cameras
         .iter()
-        .map(|cam| match cam {
+        .map(|video_source_type| match video_source_type {
             VideoSourceType::Local(cam) => ApiVideoSource {
                 name: cam.name().clone(),
                 source: cam.source_string().to_string(),
+                source_type: video_source_type.clone(),
                 formats: cam.formats(),
                 controls: cam.controls(),
             },
             VideoSourceType::Gst(gst) => ApiVideoSource {
                 name: gst.name().clone(),
                 source: gst.source_string().to_string(),
+                source_type: video_source_type.clone(),
                 formats: gst.formats(),
                 controls: gst.controls(),
             },
             VideoSourceType::Redirect(redirect) => ApiVideoSource {
                 name: redirect.name().clone(),
                 source: redirect.source_string().to_string(),
+                source_type: video_source_type.clone(),
                 formats: redirect.formats(),
                 controls: redirect.controls(),
             },

--- a/src/settings/manager.rs
+++ b/src/settings/manager.rs
@@ -268,6 +268,7 @@ mod tests {
             video_source: VideoSourceType::Local(VideoSourceLocal {
                 name: "Fake Potato Test Video Source Camera".into(),
                 device_path: "/dev/potatovideo".into(),
+                v4l_by_path: "".into(),
                 typ: VideoSourceLocalType::Usb("usb-0420:08:47.42-77".into()),
             }),
         }];

--- a/src/stream/stream_backend.rs
+++ b/src/stream/stream_backend.rs
@@ -331,6 +331,7 @@ mod tests {
             video_source: VideoSourceType::Local(VideoSourceLocal {
                 name: "PotatoCam".into(),
                 device_path: "/dev/video42".into(),
+                v4l_by_path: "".into(),
                 typ: VideoSourceLocalType::Usb("TestPotatoCam".into()),
             }),
         });


### PR DESCRIPTION
- Helps #14: gives enough information for the front-end to merge the devices from the same BUS if it wants to.
- Also gives enough information for the front-end to detect each port a USB camera is connected to (v4l_by_path).

---
## Breaking Changes:

#### 1. `VideoSourceLocal` is used in the API:

![image](https://user-images.githubusercontent.com/5920286/187786707-9e01eede-3174-40d8-843a-9ad558c3db4d.png)


#### Diff

```diff
#[derive(Apiv2Schema, Clone, Debug, Deserialize, PartialEq, Serialize)]
pub struct VideoSourceLocal {
    pub name: String,
    pub device_path: String,
+    pub v4l_by_path: String,
    #[serde(rename = "type")]
    pub typ: VideoSourceLocalType,
}
```

Because of this change on `VideoSourceLocal`, settings will also break.

That's all