### PR TITLE
Recreate streams

### DIFF
--- a/src/stream/mod.rs
+++ b/src/stream/mod.rs
@@ -6,8 +6,11 @@ pub mod sink;
 pub mod types;
 pub mod webrtc;
 
+use std::sync::{Arc, Mutex};
+
 use crate::mavlink::mavlink_camera::MavlinkCameraHandle;
 use crate::video::types::{VideoEncodeType, VideoSourceType};
+use crate::video::video_source::cameras_available;
 use crate::video_stream::types::VideoAndStreamInformation;
 
 use manager::Manager;
@@ -17,7 +20,7 @@ use types::*;
 use webrtc::signalling_protocol::PeerId;
 use webrtc::signalling_server::StreamManagementInterface;
 
-use anyhow::{anyhow, Result};
+use anyhow::{anyhow, Context, Result};
 
 use tracing::*;
 
@@ -25,7 +28,14 @@ use self::rtsp::rtsp_server::RTSP_SERVER_PORT;
 
 #[derive(Debug)]
 pub struct Stream {
-    pub id: PeerId,
+    state: Arc<Mutex<StreamState>>,
+    terminated: Arc<Mutex<bool>>,
+    _watcher_thread_handle: std::thread::JoinHandle<()>,
+}
+
+#[derive(Debug)]
+pub struct StreamState {
+    pub pipeline_id: PeerId,
     pub pipeline: Pipeline,
     pub video_and_stream_information: VideoAndStreamInformation,
     pub mavlink_camera: Option<MavlinkCameraHandle>,
@@ -34,6 +44,146 @@ pub struct Stream {
 impl Stream {
     #[instrument(level = "debug")]
     pub fn try_new(video_and_stream_information: &VideoAndStreamInformation) -> Result<Self> {
+        let pipeline_id = Manager::generate_uuid();
+
+        let state = Arc::new(Mutex::new(StreamState::try_new(
+            video_and_stream_information,
+            &pipeline_id,
+        )?));
+
+        let terminated = Arc::new(Mutex::new(false));
+        let terminated_cloned = terminated.clone();
+
+        let video_and_stream_information_cloned = video_and_stream_information.clone();
+        let state_cloned = state.clone();
+        let _watcher_thread_handle = std::thread::Builder::new()
+            .name(format!("Stream-{pipeline_id}"))
+            .spawn(move || {
+                Self::watcher(
+                    video_and_stream_information_cloned,
+                    pipeline_id,
+                    state_cloned,
+                    terminated_cloned,
+                )
+            })
+            .context(format!(
+                "Failed when spawing PipelineRunner thread for Pipeline {pipeline_id:#?}"
+            ))?;
+
+        Ok(Self {
+            state,
+            terminated,
+            _watcher_thread_handle,
+        })
+    }
+
+    #[instrument(level = "debug")]
+    fn watcher(
+        video_and_stream_information: VideoAndStreamInformation,
+        pipeline_id: uuid::Uuid,
+        state: Arc<Mutex<StreamState>>,
+        terminated: Arc<Mutex<bool>>,
+    ) {
+        // To reduce log size, each report we raise the report interval geometrically until a maximum value is reached:
+        let report_interval_mult = 2;
+        let report_interval_max = 60;
+        let mut report_interval = std::time::Duration::from_secs(1);
+        let mut last_report_time = std::time::Instant::now();
+
+        let mut video_and_stream_information = video_and_stream_information;
+
+        loop {
+            std::thread::sleep(std::time::Duration::from_millis(100));
+
+            if !state
+                .lock()
+                .unwrap()
+                .pipeline
+                .inner_state_as_ref()
+                .pipeline_runner
+                .is_running()
+            {
+                // If it's a camera, try to update the device
+                if let VideoSourceType::Local(_) = video_and_stream_information.video_source {
+                    let mut streams = vec![video_and_stream_information.clone()];
+                    let mut candidates = cameras_available();
+
+                    // Discards any source from other running streams, otherwise we'd be trying to create a stream from a device in use (which is not possible)
+                    let current_running_streams = manager::streams()
+                        .unwrap()
+                        .iter()
+                        .filter_map(|status| {
+                            status
+                                .running
+                                .then_some(status.video_and_stream.video_source.clone())
+                        })
+                        .collect::<Vec<VideoSourceType>>();
+                    candidates.retain(|candidate| !current_running_streams.contains(candidate));
+
+                    let should_report =
+                        std::time::Instant::now() - last_report_time >= report_interval;
+
+                    // Find the best candidate
+                    manager::update_devices(&mut streams, &mut candidates, should_report);
+                    video_and_stream_information = streams.first().unwrap().clone();
+
+                    // Check if the chosen video source is available
+                    match crate::video::video_source::get_video_source(
+                        video_and_stream_information
+                            .video_source
+                            .inner()
+                            .source_string(),
+                    ) {
+                        Ok(best_candidate) => {
+                            video_and_stream_information.video_source = best_candidate;
+                        }
+                        Err(error) => {
+                            if should_report {
+                                warn!("Failed to recreate the stream {pipeline_id:?}: {error:?}. Is the device connected? Trying again each second until the success or stream is removed. Next report in {report_interval:?} to reduce log size.");
+                                last_report_time = std::time::Instant::now();
+                                report_interval *= report_interval_mult;
+                                if report_interval
+                                    > std::time::Duration::from_secs(report_interval_max)
+                                {
+                                    report_interval =
+                                        std::time::Duration::from_secs(report_interval_max);
+                                }
+                            }
+
+                            std::thread::sleep(std::time::Duration::from_secs(1));
+                            continue;
+                        }
+                    }
+                }
+
+                // Try to recreate the stream
+                *state.lock().unwrap() = match StreamState::try_new(
+                    &video_and_stream_information,
+                    &pipeline_id,
+                ) {
+                    Ok(state) => state,
+                    Err(error) => {
+                        error!("Failed to recreate the stream {pipeline_id:?}: {error:#?}. Trying again in one second...");
+                        std::thread::sleep(std::time::Duration::from_secs(1));
+                        continue;
+                    }
+                };
+            }
+
+            if *terminated.lock().unwrap() {
+                debug!("Ending stream {pipeline_id:?}.");
+                break;
+            }
+        }
+    }
+}
+
+impl StreamState {
+    #[instrument(level = "debug")]
+    pub fn try_new(
+        video_and_stream_information: &VideoAndStreamInformation,
+        pipeline_id: &uuid::Uuid,
+    ) -> Result<Self> {
         if let Err(error) = validate_endpoints(video_and_stream_information) {
             return Err(anyhow!("Failed validating endpoints. Reason: {error:?}"));
         }

--- a/src/stream/mod.rs
+++ b/src/stream/mod.rs
@@ -54,7 +54,7 @@ impl Stream {
         };
 
         let mut stream = Stream {
-            id,
+            pipeline_id: *pipeline_id,
             pipeline,
             video_and_stream_information: video_and_stream_information.clone(),
             mavlink_camera,

--- a/src/stream/mod.rs
+++ b/src/stream/mod.rs
@@ -114,6 +114,11 @@ impl Stream {
             .pipeline_runner
             .start()?;
 
+        // Start all the sinks
+        for sink in stream.pipeline.inner_state_mut().sinks.values() {
+            sink.start()?
+        }
+
         Ok(stream)
     }
 }

--- a/src/stream/pipeline/fake_pipeline.rs
+++ b/src/stream/pipeline/fake_pipeline.rs
@@ -56,6 +56,9 @@ impl FakePipeline {
             }
         };
 
+        let filter_name = format!("{PIPELINE_FILTER_NAME}-{pipeline_id}");
+        let sink_tee_name = format!("{PIPELINE_SINK_TEE_NAME}-{pipeline_id}");
+
         // Fakes (videotestsrc) are only "video/x-raw" or "video/x-bayer",
         // and to be able to encode it, we need to define an available
         // format for both its src the next element's sink pad.
@@ -80,8 +83,8 @@ impl FakePipeline {
                     height = configuration.height,
                     interval_denominator = configuration.frame_interval.denominator,
                     interval_numerator = configuration.frame_interval.numerator,
-                    filter_name = format!("{PIPELINE_FILTER_NAME}-{pipeline_id}"),
-                    sink_tee_name = format!("{PIPELINE_SINK_TEE_NAME}-{pipeline_id}"),
+                    filter_name = filter_name,
+                    sink_tee_name = sink_tee_name,
                 )
             }
             VideoEncodeType::Yuyv => {
@@ -102,8 +105,8 @@ impl FakePipeline {
                     height = configuration.height,
                     interval_denominator = configuration.frame_interval.denominator,
                     interval_numerator = configuration.frame_interval.numerator,
-                    filter_name = format!("{PIPELINE_FILTER_NAME}-{pipeline_id}"),
-                    sink_tee_name = format!("{PIPELINE_SINK_TEE_NAME}-{pipeline_id}"),
+                    filter_name = filter_name,
+                    sink_tee_name = sink_tee_name,
                 )
             }
             VideoEncodeType::Mjpg => {
@@ -122,8 +125,8 @@ impl FakePipeline {
                     height = configuration.height,
                     interval_denominator = configuration.frame_interval.denominator,
                     interval_numerator = configuration.frame_interval.numerator,
-                    filter_name = format!("{PIPELINE_FILTER_NAME}-{pipeline_id}"),
-                    sink_tee_name = format!("{PIPELINE_SINK_TEE_NAME}-{pipeline_id}"),
+                    filter_name = filter_name,
+                    sink_tee_name = sink_tee_name,
                 )
             }
             unsupported => {

--- a/src/stream/pipeline/fake_pipeline.rs
+++ b/src/stream/pipeline/fake_pipeline.rs
@@ -25,7 +25,7 @@ pub struct FakePipeline {
 impl FakePipeline {
     #[instrument(level = "debug")]
     pub fn try_new(
-        pipeline_id: uuid::Uuid,
+        pipeline_id: &uuid::Uuid,
         video_and_stream_information: &VideoAndStreamInformation,
     ) -> Result<gst::Pipeline> {
         let configuration = match &video_and_stream_information

--- a/src/stream/pipeline/mod.rs
+++ b/src/stream/pipeline/mod.rs
@@ -238,6 +238,9 @@ impl PipelineState {
             format!("pipeline-{pipeline_id}-sink-{sink_id}-before-removing"),
         );
 
+        // Terminate the Sink
+        sink.eos();
+
         // Unlink the Sink
         sink.unlink(pipeline, pipeline_id)?;
 

--- a/src/stream/pipeline/redirect_pipeline.rs
+++ b/src/stream/pipeline/redirect_pipeline.rs
@@ -19,7 +19,7 @@ pub struct RedirectPipeline {
 impl RedirectPipeline {
     #[instrument(level = "debug")]
     pub fn try_new(
-        pipeline_id: uuid::Uuid,
+        pipeline_id: &uuid::Uuid,
         video_and_stream_information: &VideoAndStreamInformation,
     ) -> Result<gst::Pipeline> {
         match &video_and_stream_information

--- a/src/stream/pipeline/redirect_pipeline.rs
+++ b/src/stream/pipeline/redirect_pipeline.rs
@@ -57,6 +57,8 @@ impl RedirectPipeline {
             .first()
             .context("Failed to access the fisrt endpoint")?;
 
+        let sink_tee_name = format!("{PIPELINE_SINK_TEE_NAME}-{pipeline_id}");
+
         let description = match url.scheme() {
             "rtsp" => {
                 format!(
@@ -66,7 +68,7 @@ impl RedirectPipeline {
                         " ! tee name={sink_tee_name} allow-not-linked=true"
                     ),
                     location = url,
-                    sink_tee_name = format!("{PIPELINE_SINK_TEE_NAME}-{pipeline_id}"),
+                    sink_tee_name = sink_tee_name,
                 )
             }
             "udp" => {
@@ -78,7 +80,7 @@ impl RedirectPipeline {
                     ),
                     address = url.host().context("UDP URL without host")?,
                     port = url.port().context("UDP URL without port")?,
-                    sink_tee_name = format!("{PIPELINE_SINK_TEE_NAME}-{pipeline_id}"),
+                    sink_tee_name = sink_tee_name,
                 )
             }
             unsupported => {

--- a/src/stream/pipeline/runner.rs
+++ b/src/stream/pipeline/runner.rs
@@ -21,7 +21,7 @@ impl PipelineRunner {
     #[instrument(level = "debug")]
     pub fn try_new(
         pipeline: &gst::Pipeline,
-        pipeline_id: uuid::Uuid,
+        pipeline_id: &uuid::Uuid,
         allow_block: bool,
     ) -> Result<Self> {
         let pipeline_weak = pipeline.downgrade();
@@ -83,9 +83,7 @@ impl PipelineRunner {
     #[instrument(level = "debug")]
     fn runner(
         pipeline_weak: gst::glib::WeakRef<gst::Pipeline>,
-        pipeline_id: uuid::Uuid,
-        mut killswitch_receiver: broadcast::Receiver<String>,
-        mut start_signal_receiver: broadcast::Receiver<()>,
+        pipeline_id: &uuid::Uuid,
         allow_block: bool,
     ) -> Result<()> {
         let pipeline = pipeline_weak

--- a/src/stream/pipeline/runner.rs
+++ b/src/stream/pipeline/runner.rs
@@ -98,10 +98,9 @@ impl PipelineRunner {
                     100,
                     5,
                 ) {
-                    error!(
+                    return Err(anyhow!(
                         "Failed setting Pipeline {pipeline_id} to Playing state. Reason: {error:?}"
-                    );
-                    continue;
+                    ));
                 }
             }
 

--- a/src/stream/pipeline/runner.rs
+++ b/src/stream/pipeline/runner.rs
@@ -141,7 +141,7 @@ impl PipelineRunner {
 
                     match msg.view() {
                         MessageView::Eos(eos) => {
-                            warn!("Received EndOfStream: {eos:#?}");
+                            debug!("Received EndOfStream: {eos:?}");
                             pipeline.debug_to_dot_file_with_ts(
                                 gst::DebugGraphDetails::all(),
                                 format!("pipeline-{pipeline_id}-eos"),

--- a/src/stream/pipeline/runner.rs
+++ b/src/stream/pipeline/runner.rs
@@ -115,16 +115,15 @@ impl PipelineRunner {
                                     && current_previous_position == position
                                 {
                                     lost_timestamps += 1;
-                                    warn!("Position did not change {lost_timestamps}");
-                                } else {
+                                } else if lost_timestamps > 0 {
                                     // We are back in track, erase lost timestamps
+                                    warn!("Position normalized, but didn't changed for {lost_timestamps} timestamps");
                                     lost_timestamps = 0;
                                 }
-
-                                if lost_timestamps > max_lost_timestamps {
-                                    warn!("Pipeline lost too many timestamps (max. was {max_lost_timestamps}).");
-                                    lost_timestamps = 0;
-                                    break 'inner;
+                                if lost_timestamps == 1 {
+                                    warn!("Position did not change for {lost_timestamps}, silently tracking until {max_lost_timestamps}, then the stream will be recreated");
+                                } else if lost_timestamps > max_lost_timestamps {
+                                    return Err(anyhow!("Pipeline lost too many timestamps (max. was {max_lost_timestamps})"));
                                 }
 
                                 Some(position)

--- a/src/stream/pipeline/runner.rs
+++ b/src/stream/pipeline/runner.rs
@@ -228,21 +228,3 @@ impl PipelineRunner {
         Ok(())
     }
 }
-
-impl Drop for PipelineRunner {
-    #[instrument(level = "debug", skip(self))]
-    fn drop(&mut self) {
-        if let Some(pipeline) = self.pipeline_weak.upgrade() {
-            pipeline.send_event(gst::event::Eos::new());
-        }
-
-        if let Err(reason) = self
-            .killswitch_sender
-            .send("PipelineRunner Dropped.".to_string())
-        {
-            warn!(
-                "Failed to send killswitch message while Dropping PipelineRunner. Reason: {reason:#?}"
-            );
-        }
-    }
-}

--- a/src/stream/pipeline/v4l_pipeline.rs
+++ b/src/stream/pipeline/v4l_pipeline.rs
@@ -22,7 +22,7 @@ pub struct V4lPipeline {
 impl V4lPipeline {
     #[instrument(level = "debug")]
     pub fn try_new(
-        pipeline_id: uuid::Uuid,
+        pipeline_id: &uuid::Uuid,
         video_and_stream_information: &VideoAndStreamInformation,
     ) -> Result<gst::Pipeline> {
         let configuration = match &video_and_stream_information

--- a/src/stream/pipeline/v4l_pipeline.rs
+++ b/src/stream/pipeline/v4l_pipeline.rs
@@ -47,6 +47,8 @@ impl V4lPipeline {
         let height = configuration.height;
         let interval_numerator = configuration.frame_interval.numerator;
         let interval_denominator = configuration.frame_interval.denominator;
+        let filter_name = format!("{PIPELINE_FILTER_NAME}-{pipeline_id}");
+        let sink_tee_name = format!("{PIPELINE_SINK_TEE_NAME}-{pipeline_id}");
 
         let description = match &configuration.encode {
             VideoEncodeType::H264 => {
@@ -63,8 +65,8 @@ impl V4lPipeline {
                     height = height,
                     interval_denominator = interval_denominator,
                     interval_numerator = interval_numerator,
-                    filter_name = format!("{PIPELINE_FILTER_NAME}-{pipeline_id}"),
-                    sink_tee_name = format!("{PIPELINE_SINK_TEE_NAME}-{pipeline_id}"),
+                    filter_name = filter_name,
+                    sink_tee_name = sink_tee_name,
                 )
             }
             VideoEncodeType::Yuyv => {
@@ -81,8 +83,8 @@ impl V4lPipeline {
                     height = height,
                     interval_denominator = interval_denominator,
                     interval_numerator = interval_numerator,
-                    filter_name = format!("{PIPELINE_FILTER_NAME}-{pipeline_id}"),
-                    sink_tee_name = format!("{PIPELINE_SINK_TEE_NAME}-{pipeline_id}"),
+                    filter_name = filter_name,
+                    sink_tee_name = sink_tee_name
                 )
             }
             VideoEncodeType::Mjpg => {
@@ -99,8 +101,8 @@ impl V4lPipeline {
                     height = height,
                     interval_denominator = interval_denominator,
                     interval_numerator = interval_numerator,
-                    filter_name = format!("{PIPELINE_FILTER_NAME}-{pipeline_id}"),
-                    sink_tee_name = format!("{PIPELINE_SINK_TEE_NAME}-{pipeline_id}"),
+                    filter_name = filter_name,
+                    sink_tee_name = sink_tee_name
                 )
             }
             unsupported => {

--- a/src/stream/sink/mod.rs
+++ b/src/stream/sink/mod.rs
@@ -38,6 +38,12 @@ pub trait SinkInterface {
     ///
     /// For a better grasp of SDP parameters, read [here](https://www.iana.org/assignments/sdp-parameters/sdp-parameters.xhtml)
     fn get_sdp(&self) -> Result<gst_sdp::SDPMessage>;
+
+    /// Start the Sink
+    fn start(&self) -> Result<()>;
+
+    /// Terminates the Sink
+    fn eos(&self);
 }
 
 #[enum_dispatch(SinkInterface)]

--- a/src/stream/sink/rtsp_sink.rs
+++ b/src/stream/sink/rtsp_sink.rs
@@ -209,6 +209,14 @@ impl SinkInterface for RtspSink {
             "Not available. Reason: RTSP Sink should only be connected from its RTSP endpoint."
         ))
     }
+
+    #[instrument(level = "debug", skip(self))]
+    fn start(&self) -> Result<()> {
+        Ok(())
+    }
+
+    #[instrument(level = "debug", skip(self))]
+    fn eos(&self) {}
 }
 
 impl RtspSink {

--- a/src/stream/sink/webrtc_sink.rs
+++ b/src/stream/sink/webrtc_sink.rs
@@ -113,6 +113,7 @@ impl SinkInterface for WebRTCSink {
         self.0.lock().unwrap().get_id()
     }
 
+    #[instrument(level = "debug", skip(self))]
     fn get_sdp(&self) -> Result<gst_sdp::SDPMessage> {
         self.0.lock().unwrap().get_sdp()
     }

--- a/src/stream/sink/webrtc_sink.rs
+++ b/src/stream/sink/webrtc_sink.rs
@@ -116,6 +116,16 @@ impl SinkInterface for WebRTCSink {
     fn get_sdp(&self) -> Result<gst_sdp::SDPMessage> {
         self.0.lock().unwrap().get_sdp()
     }
+
+    #[instrument(level = "debug", skip(self))]
+    fn start(&self) -> Result<()> {
+        self.0.lock().unwrap().start()
+    }
+
+    #[instrument(level = "debug", skip(self))]
+    fn eos(&self) {
+        self.0.lock().unwrap().eos()
+    }
 }
 
 impl WebRTCSink {
@@ -659,6 +669,18 @@ impl SinkInterface for WebRTCSinkInner {
         Err(anyhow!(
             "Not available: WebRTC Sink should only be connected by means of its Signalling protocol."
         ))
+    }
+
+    #[instrument(level = "debug", skip(self))]
+    fn start(&self) -> Result<()> {
+        Ok(())
+    }
+
+    #[instrument(level = "debug", skip(self))]
+    fn eos(&self) {
+        if let Err(error) = self.webrtcbin.post_message(gst::message::Eos::new()) {
+            error!("Failed posting Eos message into Sink bus. Reason: {error:?}");
+        }
     }
 }
 


### PR DESCRIPTION
When a camera is disconnected during a stream, the system searches for the best device candidates that match the characteristics of the one in use on that stream, and recreates the stream from the ground up (while keeping the same pipeline ID). In the case of more than one stream running, the system discards any other device in the other stream.

To achieve that, the owner of the `<VideoAndStreamInformation>` was changed from the `<PipelineState>` (the inner state of each kind of `<Pipeline>`) to the `<Stream>`, while we moved part of the `<Stream>`'s fields to a thread-safe inner state called `<StreamState>`.

Closes #206
Closes #223
Closes #226

It's working, but it's a draft until I:
- [x] Organize the thread communication/end-of-life;
- [x] Make the recreated streams use the same ID as the killed one;
- [x] Avoid huge logs by reporting at geometrically growing intervals;