### PR TITLE
Add H265 support - Part I: Fake + V4L2

### DIFF
--- a/src/lib/mavlink/mavlink_camera.rs
+++ b/src/lib/mavlink/mavlink_camera.rs
@@ -82,7 +82,7 @@ impl MavlinkCameraInner {
 
         let mavlink_stream_type = match video_stream_uri.scheme() {
             "rtsp" => mavlink::common::VideoStreamType::VIDEO_STREAM_TYPE_RTSP,
-            "udp" => mavlink::common::VideoStreamType::VIDEO_STREAM_TYPE_RTPUDP,
+            "udp" | "udp265" => mavlink::common::VideoStreamType::VIDEO_STREAM_TYPE_RTPUDP,
             unsupported => {
                 return Err(anyhow!(
                     "Scheme {unsupported:#?} is not supported for a Mavlink Camera."

--- a/src/lib/stream/mod.rs
+++ b/src/lib/stream/mod.rs
@@ -404,9 +404,9 @@ fn validate_endpoints(video_and_stream_information: &VideoAndStreamInformation) 
             VideoSourceType::Redirect(_)
         ) {
             match scheme {
-                "udp" | "rtsp" => return None,
+                "udp" | "udp265" | "rtsp" => return None,
                 _ => return Some(anyhow!(
-                    "The URL's scheme for REDIRECT endpoints should be \"udp\" or \"rtsp\", but was: {scheme:?}",
+                    "The URL's scheme for REDIRECT endpoints should be \"udp\", \"udp265\", or \"rtsp\", but was: {scheme:?}",
                 ))
             };
         }

--- a/src/lib/stream/pipeline/fake_pipeline.rs
+++ b/src/lib/stream/pipeline/fake_pipeline.rs
@@ -91,6 +91,29 @@ impl FakePipeline {
                     rtp_tee_name = rtp_tee_name,
                 )
             }
+            VideoEncodeType::H265 => {
+                format!(concat!(
+                        "videotestsrc pattern={pattern} is-live=true do-timestamp=true",
+                        " ! timeoverlay",
+                        " ! video/x-raw,format=I420",
+                        " ! x265enc tune=zerolatency speed-preset=ultrafast bitrate=5000",
+                        " ! h265parse",
+                        " ! capsfilter name={filter_name} caps=video/x-h265,profile={profile},stream-format=byte-stream,alignment=au,width={width},height={height},framerate={interval_denominator}/{interval_numerator}",
+                        " ! tee name={video_tee_name} allow-not-linked=true",
+                        " ! rtph265pay aggregate-mode=zero-latency config-interval=10 pt=96",
+                        " ! tee name={rtp_tee_name} allow-not-linked=true"
+                    ),
+                    pattern = pattern,
+                    profile = "main",
+                    width = configuration.width,
+                    height = configuration.height,
+                    interval_denominator = configuration.frame_interval.denominator,
+                    interval_numerator = configuration.frame_interval.numerator,
+                    filter_name = filter_name,
+                    video_tee_name = video_tee_name,
+                    rtp_tee_name = rtp_tee_name,
+                )
+            }
             VideoEncodeType::Yuyv => {
                 format!(
                     concat!(

--- a/src/lib/stream/pipeline/v4l_pipeline.rs
+++ b/src/lib/stream/pipeline/v4l_pipeline.rs
@@ -73,6 +73,26 @@ impl V4lPipeline {
                     rtp_tee_name = rtp_tee_name,
                 )
             }
+            VideoEncodeType::H265 => {
+                format!(
+                    concat!(
+                        "v4l2src device={device} do-timestamp=true",
+                        " ! h265parse",
+                        " ! capsfilter name={filter_name} caps=video/x-h265,stream-format=byte-stream,alignment=au,width={width},height={height},framerate={interval_denominator}/{interval_numerator}",
+                        " ! tee name={video_tee_name} allow-not-linked=true",
+                        " ! rtph265pay aggregate-mode=zero-latency config-interval=10 pt=96",
+                        " ! tee name={rtp_tee_name} allow-not-linked=true"
+                    ),
+                    device = device,
+                    width = width,
+                    height = height,
+                    interval_denominator = interval_denominator,
+                    interval_numerator = interval_numerator,
+                    filter_name = filter_name,
+                    video_tee_name = video_tee_name,
+                    rtp_tee_name = rtp_tee_name,
+                )
+            }
             VideoEncodeType::Yuyv => {
                 format!(
                     concat!(

--- a/src/lib/stream/pipeline/v4l_pipeline.rs
+++ b/src/lib/stream/pipeline/v4l_pipeline.rs
@@ -57,7 +57,7 @@ impl V4lPipeline {
                 format!(
                     concat!(
                         "v4l2src device={device} do-timestamp=true",
-                        " ! h264parse",  // Here we need the parse to help the stream-format and alignment part, which is being fixed here because avc/au seems to reduce the CPU usage in the RTP payloading part.
+                        " ! h264parse",  // Here we need the parse to help the stream-format and alignment part, which is being fixated here because avc/au seems to reduce the CPU usage in the RTP payloading part.
                         " ! capsfilter name={filter_name} caps=video/x-h264,stream-format=avc,alignment=au,width={width},height={height},framerate={interval_denominator}/{interval_numerator}",
                         " ! tee name={video_tee_name} allow-not-linked=true",
                         " ! rtph264pay aggregate-mode=zero-latency config-interval=10 pt=96",

--- a/src/lib/stream/rtsp/rtsp_server.rs
+++ b/src/lib/stream/rtsp/rtsp_server.rs
@@ -175,6 +175,19 @@ impl RTSPServer {
                     rtp_caps = rtp_caps,
                 )
             }
+            "H265" => {
+                format!(
+                    concat!(
+                        "shmsrc socket-path={socket_path} do-timestamp=true is-live=false",
+                        " ! queue leaky=downstream flush-on-eos=true silent=true max-size-buffers=0",
+                        " ! capsfilter caps={rtp_caps:?}",
+                        " ! rtph265depay",
+                        " ! rtph265pay name=pay0 aggregate-mode=zero-latency config-interval=10 pt=96",
+                    ),
+                    socket_path = socket_path,
+                    rtp_caps = rtp_caps,
+                )
+            }
             "RAW" => {
                 format!(
                     concat!(

--- a/src/lib/stream/sink/image_sink.rs
+++ b/src/lib/stream/sink/image_sink.rs
@@ -357,6 +357,20 @@ impl ImageSink {
                 _transcoding_elements.push(filter);
                 _transcoding_elements.push(decoder);
             }
+            VideoEncodeType::H265 => {
+                // For h265, we need to filter-out unwanted non-key frames here, before decoding it.
+                let filter = gst::ElementFactory::make("identity")
+                .property("drop-buffer-flags", gst::BufferFlags::DELTA_UNIT)
+                .property("sync", false)
+                .build()?;
+                let decoder = gst::ElementFactory::make("avdec_h265")
+                    .property_from_str("lowres", "2") // (0) is 'full'; (1) is '1/2-size'; (2) is '1/4-size'
+                    .build()?;
+                decoder.has_property("discard-corrupted-frames", None).then(|| decoder.set_property("discard-corrupted-frames", true));
+                decoder.has_property("std-compliance", None).then(|| decoder.set_property_from_str("std-compliance", "normal"));
+                _transcoding_elements.push(filter);
+                _transcoding_elements.push(decoder);
+            }
             VideoEncodeType::Mjpg => {
                 let decoder = gst::ElementFactory::make("jpegdec").build()?;
                 decoder.has_property("discard-corrupted-frames", None).then(|| decoder.set_property("discard-corrupted-frames", true));

--- a/src/lib/stream/sink/udp_sink.rs
+++ b/src/lib/stream/sink/udp_sink.rs
@@ -322,7 +322,7 @@ impl UdpSink {
         let clients = addresses
             .iter()
             .filter_map(|address| {
-                if address.scheme() != "udp" {
+                if !matches!(address.scheme(), "udp" | "udp265") {
                     return None;
                 }
                 if let (Some(host), Some(port)) = (address.host(), address.port()) {

--- a/src/lib/stream/sink/webrtc_sink.rs
+++ b/src/lib/stream/sink/webrtc_sink.rs
@@ -564,8 +564,10 @@ impl WebRTCBinInterface for WebRTCSinkWeakProxy {
         offer: &gst_webrtc::WebRTCSessionDescription,
     ) -> Result<()> {
         // Recreate the SDP offer with our customized SDP
-        let offer =
-            gst_webrtc::WebRTCSessionDescription::new(offer.type_(), customize_sdp(&offer.sdp())?);
+        let offer = gst_webrtc::WebRTCSessionDescription::new(
+            offer.type_(),
+            customize_sent_sdp(&offer.sdp())?,
+        );
 
         let Ok(sdp) = offer.sdp().as_text() else {
             return Err(anyhow!("Failed reading the received SDP"));
@@ -601,7 +603,7 @@ impl WebRTCBinInterface for WebRTCSinkWeakProxy {
         // Recreate the SDP answer with our customized SDP
         let answer = gst_webrtc::WebRTCSessionDescription::new(
             answer.type_(),
-            customize_sdp(&answer.sdp())?,
+            customize_sent_sdp(&answer.sdp())?,
         );
 
         let Ok(sdp) = answer.sdp().as_text() else {
@@ -738,40 +740,104 @@ impl WebRTCBinInterface for WebRTCSinkWeakProxy {
     }
 }
 
-/// Because GSTreamer's WebRTCBin often crashes when receiving an invalid SDP,
+/// Because GStreamer's WebRTCBin often crashes when receiving an invalid SDP,
 /// we use Mozzila's SDP parser to manipulate the SDP Message before giving it to GStreamer
-#[instrument(level = "debug")]
-fn customize_sdp(sdp: &gst_sdp::SDPMessage) -> Result<gst_sdp::SDPMessage> {
-    let mut sdp = webrtc_sdp::parse_sdp(sdp.as_text()?.as_str(), false)?;
+#[instrument(level = "debug", skip_all)]
+fn sanitize_sdp(sdp: &gst_sdp::SDPMessage) -> Result<gst_sdp::SDPMessage> {
+    gst_sdp::SDPMessage::parse_buffer(
+        webrtc_sdp::parse_sdp(sdp.as_text()?.as_str(), false)?
+            .to_string()
+            .as_bytes(),
+    )
+    .map_err(anyhow::Error::msg)
+}
 
-    for media in sdp.media.iter_mut() {
-        let attributes = media.get_attributes().to_vec(); // This clone is necessary to avoid imutable borrow after a mutable borrow
-        for attribute in attributes {
-            use webrtc_sdp::attribute_type::SdpAttribute::*;
+#[instrument(level = "debug", skip_all)]
+fn customize_sent_sdp(sdp: &gst_sdp::SDPMessage) -> Result<gst_sdp::SDPMessage> {
+    let mut new_sdp = sdp.clone();
 
-            match attribute {
-                // Filter out unsupported/unwanted attributes
-                Recvonly | Sendrecv | Inactive => {
-                    media.remove_attribute((&attribute).into());
-                    debug!("Removed unsupported/unwanted attribute: {attribute:?}");
-                }
-                // Customize FMTP
-                // Here we are lying to the peer about our profile-level-id (to constrained-baseline) so any browser can accept it
-                Fmtp(mut fmtp) => {
-                    const CONSTRAINED_BASELINE_LEVEL_ID: u32 = 0x42e01f;
-                    fmtp.parameters.profile_level_id = CONSTRAINED_BASELINE_LEVEL_ID;
-                    fmtp.parameters.level_asymmetry_allowed = true;
+    new_sdp.medias_mut().enumerate().for_each(|(media_idx, media)| {
+        let old_media = sdp.media(media_idx as u32).unwrap();
 
-                    let attribute = webrtc_sdp::attribute_type::SdpAttribute::Fmtp(fmtp);
-
-                    debug!("FMTP attribute customized: {attribute:?}");
-
-                    media.set_attribute(attribute)?;
-                }
-                _ => continue,
+        old_media.attributes().for_each(|attribute| {
+            if attribute.key().ne("rtpmap") {
+                return;
             }
-        }
-    }
 
-    gst_sdp::SDPMessage::parse_buffer(sdp.to_string().as_bytes()).map_err(anyhow::Error::msg)
+            let value = attribute.value().unwrap_or_default();
+
+            trace!("Found a rtpmap attribute w/ value: {value:?}");
+
+            lazy_static! {
+                // Looking for something like "96 H264/90000"
+                static ref RE: regex::Regex = regex::Regex::new(
+                    r"(?P<payload>[0-9]*)\s(?P<encoding>[0-9A-Za-z_]{4})/(?P<clockrate>[0-9]*)"
+                )
+                .unwrap();
+            }
+
+            let Some(caps) = RE.captures(value) else {
+                return;
+            };
+            let payload = &caps["payload"];
+            let encoding = &caps["encoding"];
+            let clockrate = &caps["clockrate"];
+
+            trace!("rtpmap attribute parsed: payload: {payload:?}, encoding: {encoding:?}, clockrate: {clockrate:?}");
+
+            if let Some((fmtp_idx, fmtp_attribute)) =
+                old_media.attributes().enumerate().find(|(_, attribute)| {
+                    attribute.key().eq("fmtp")
+                        && attribute
+                            .value()
+                            .map(|v| v.starts_with(payload))
+                            .unwrap_or(false)
+                })
+            {
+                let value = fmtp_attribute
+                .value()
+                .expect("The fmtp we have found should have a value");
+
+                trace!("Found a fmtp attribute: {value:?}");
+
+                let Some((payload, values)) = value.split_once(' ') else {
+                    return;
+                };
+
+                trace!("fmtp attribute parsed: payload: {payload:?}, values: {values:?}");
+
+                let mut new_value = vec![payload.to_string()];
+
+                match encoding {
+                    "H264" => {
+                        // Reference: https://www.iana.org/assignments/media-types/video/H264
+                        const CONSTRAINED_BASELINE_LEVEL_ID: u32 = 0x42e01f;
+                        new_value.push(format!("profile-level-id={CONSTRAINED_BASELINE_LEVEL_ID}"));
+                        new_value.push("level-asymmetry-allowed=1".to_string());
+                        new_value.push("packetization-mode=1".to_string());
+                    }
+                    "H265" => {
+                        // Rererence: https://www.iana.org/assignments/media-types/video/H265
+                        const LEVEL_ID: u8 = 93;
+                        new_value.push(format!("level-id={LEVEL_ID}"));
+                    }
+                    _ => (),
+                }
+
+                new_value.push(values.to_string());
+
+                let new_value = new_value.join(" ");
+
+                let new_fmtp_attribute = gst_sdp::SDPAttribute::new("fmtp", Some(&new_value));
+
+                if let Err(error) = media.replace_attribute(fmtp_idx as u32, new_fmtp_attribute) {
+                    warn!("Failed to customize fmtp attribute from {value:?} to {new_value:?}. Error: {error:?}");
+                }
+
+                trace!("fmtp attribute changed from {value:?} to {new_value:?}");
+            }
+        });
+    });
+
+    Ok(new_sdp)
 }

--- a/src/lib/stream/sink/webrtc_sink.rs
+++ b/src/lib/stream/sink/webrtc_sink.rs
@@ -479,7 +479,7 @@ impl WebRTCSink {
         }
     }
 
-    #[instrument(level = "debug", skip(self))]
+    #[instrument(level = "debug", skip(self, sdp))]
     pub fn handle_sdp(&self, sdp: &gst_webrtc::WebRTCSessionDescription) -> Result<()> {
         self.downgrade().handle_sdp(&self.webrtcbin, sdp)
     }
@@ -557,7 +557,7 @@ impl WebRTCBinInterface for WebRTCSinkWeakProxy {
 
     // Once webrtcbin has create the offer SDP for us, handle it by sending it to the peer via the
     // WebSocket connection
-    #[instrument(level = "debug", skip(self, webrtcbin))]
+    #[instrument(level = "debug", skip_all)]
     fn on_offer_created(
         &self,
         webrtcbin: &gst::Element,
@@ -570,7 +570,7 @@ impl WebRTCBinInterface for WebRTCSinkWeakProxy {
         );
 
         let Ok(sdp) = offer.sdp().as_text() else {
-            return Err(anyhow!("Failed reading the received SDP"));
+            return Err(anyhow!("Failed reading the created SDP"));
         };
 
         // All good, then set local description
@@ -607,7 +607,7 @@ impl WebRTCBinInterface for WebRTCSinkWeakProxy {
         );
 
         let Ok(sdp) = answer.sdp().as_text() else {
-            return Err(anyhow!("Failed reading the received SDP"));
+            return Err(anyhow!("Failed reading the answer SDP"));
         };
 
         debug!("Sending SDP answer to peer. Answer:\n{sdp}");

--- a/src/lib/video/local/video_source_local_linux.rs
+++ b/src/lib/video/local/video_source_local_linux.rs
@@ -18,9 +18,6 @@ use tracing::*;
 use lazy_static::lazy_static;
 
 lazy_static! {
-    static ref H264_PROFILES: Arc<Mutex<HashMap<String, String>>> = Default::default();
-}
-lazy_static! {
     static ref VIDEO_FORMATS: Arc<Mutex<HashMap<String, Vec<Format>>>> = Default::default();
 }
 

--- a/src/lib/video/types.rs
+++ b/src/lib/video/types.rs
@@ -68,6 +68,7 @@ impl VideoEncodeType {
         let fourcc = fourcc.to_uppercase();
         match fourcc.as_str() {
             "H264" => VideoEncodeType::H264,
+            "H265" | "HEVC" => VideoEncodeType::H265,
             "MJPG" => VideoEncodeType::Mjpg,
             "YUYV" => VideoEncodeType::Yuyv,
             _ => VideoEncodeType::Unknown(fourcc),

--- a/src/lib/video/video_source_gst.rs
+++ b/src/lib/video/video_source_gst.rs
@@ -72,6 +72,10 @@ impl VideoSource for VideoSourceGst {
                         sizes: sizes.clone(),
                     },
                     Format {
+                        encode: VideoEncodeType::H265,
+                        sizes: sizes.clone(),
+                    },
+                    Format {
                         encode: VideoEncodeType::Yuyv,
                         sizes: sizes.clone(),
                     },

--- a/src/lib/video/video_source_gst.rs
+++ b/src/lib/video/video_source_gst.rs
@@ -48,6 +48,7 @@ impl VideoSource for VideoSourceGst {
                     .collect();
 
                 let sizes: Vec<Size> = [
+                    (160, 120),
                     (320, 240),
                     (640, 480),
                     (720, 480),


### PR DESCRIPTION
What to test:
- [x] Create fakesrc h265 UDP and receive via GStreamer
- [x] Create fakesrc h265 RTSP and receive via GStreamer
- [ ] Create fakesrc h265 UDP and receive via QGC
- [x] Create fakesrc h265 RTSP and receive via QGC
- [x] Create fakesrc h265 UDP or RTSP and receive via WebRTC¹
- [x] Create USB camera h265 UDP or RTSP and receive via WebRTC¹

¹: It works on Safari 18, but for 17.6, the H265 feature flag needs to be enabled.

---

To receive from UDP:
```bash
gst-launch-1.0 -vc \
    udpsrc address=127.0.0.1 port=5600 close-socket=false auto-multicast=true \
    ! application/x-rtp, payload=96 \
    ! rtph265depay \
    ! avdec_h265 std-compliance=normal \
    ! videoconvert \
    ! autovideosink sync=false
```

To receive from RTSP:
```bash
gst-launch-1.0 -vc \
    rtspsrc location=rtsp://0.0.0.0:8554/0 latency=0 \
    ! application/x-rtp, payload=96 \
    ! rtph265depay \
    ! avdec_h265 std-compliance=normal \
    ! videoconvert \
    ! autovideosink sync=false
```

---

Useful to check if the system supports H265 decoding (which doesn't mean it supports it via WebRTC): 
1. open [video_demo_hevc](https://lf-tk-sg.ibytedtos.com/obj/tcs-client-sg/resources/video_demo_hevc.html)
2. open `chrome://media-internals`