### PR TITLE
src: stream: image_sink: Only set property if it exists

### DIFF
--- a/src/stream/sink/image_sink.rs
+++ b/src/stream/sink/image_sink.rs
@@ -334,11 +334,10 @@ impl ImageSink {
                 let parser = gst::ElementFactory::make("h264parse").build()?;
                 // For h264, we need to filter-out unwanted non-key frames here, before decoding it.
                 let filter = gst::ElementFactory::make("identity")
-                .property("drop-buffer-flags", gst::BufferFlags::DELTA_UNIT)
-                .property("sync", false)
-                .build()?;
+                    .property("drop-buffer-flags", gst::BufferFlags::DELTA_UNIT)
+                    .property("sync", false)
+                    .build()?;
                 let decoder = gst::ElementFactory::make("avdec_h264")
-                    .property("discard-corrupted-frames", true)
                     .property_from_str("lowres", "2") // (0) is 'full'; (1) is '1/2-size'; (2) is '1/4-size'
                     .build()?;
                 _transcoding_elements.push(depayloader);

--- a/src/stream/sink/image_sink.rs
+++ b/src/stream/sink/image_sink.rs
@@ -340,6 +340,7 @@ impl ImageSink {
                 let decoder = gst::ElementFactory::make("avdec_h264")
                     .property_from_str("lowres", "2") // (0) is 'full'; (1) is '1/2-size'; (2) is '1/4-size'
                     .build()?;
+                decoder.has_property("discard-corrupted-frames", None).then(|| decoder.set_property("discard-corrupted-frames", true));
                 _transcoding_elements.push(depayloader);
                 _transcoding_elements.push(parser);
                 _transcoding_elements.push(filter);
@@ -348,9 +349,8 @@ impl ImageSink {
             VideoEncodeType::Mjpg => {
                 let depayloader = gst::ElementFactory::make("rtpjpegdepay").build()?;
                 let parser = gst::ElementFactory::make("jpegparse").build()?;
-                let decoder = gst::ElementFactory::make("jpegdec")
-                    .property("discard-corrupted-frames", true)
-                    .build()?;
+                let decoder = gst::ElementFactory::make("jpegdec").build()?;
+                decoder.has_property("discard-corrupted-frames", None).then(|| decoder.set_property("discard-corrupted-frames", true));
                 _transcoding_elements.push(depayloader);
                 _transcoding_elements.push(parser);
                 _transcoding_elements.push(decoder);


### PR DESCRIPTION
This prevents panicking when the `discard-corrupted-frames` property is not available (old GStreamer)