### PR TITLE
src: html: index: Avoid using absolute path for webrtc

### DIFF
--- a/src/html/index.html
+++ b/src/html/index.html
@@ -68,7 +68,7 @@
             </div>
             <div>
                 <h3>Streams</h3>
-                <button type="button" v-on:click="openWebsiteInTab('/webrtc/index.html')">WebRTC website</button>
+                <button type="button" v-on:click="openWebsiteInTab('webrtc/index.html')">WebRTC website</button>
                 <div v-for="stream in streams">
                     <div>
                         <h3>Name: {{ stream.video_and_stream.name }}</h3>


### PR DESCRIPTION
When mcm is running under nginx or something else, the redirects will not work if we use absolute paths. 