### PR TITLE
src: Get video formats using Device Monitor

### DIFF
--- a/src/lib/stream/manager.rs
+++ b/src/lib/stream/manager.rs
@@ -17,7 +17,10 @@ use crate::{
         types::CaptureConfiguration,
         webrtc::signalling_protocol::BindAnswer,
     },
-    video::{types::VideoSourceType, video_source},
+    video::{
+        types::{Format, VideoSourceType},
+        video_source::{self, VideoSourceFormats},
+    },
     video_stream::types::VideoAndStreamInformation,
 };
 
@@ -151,8 +154,24 @@ pub async fn update_devices(
             continue;
         };
 
+        // Only resolve formats for candidates sharing the source name so that mismatched
+        // candidates (which are filtered out by name first) don't trigger device probing.
+        let mut formats: HashMap<String, Vec<Format>> = HashMap::new();
+        for candidate in candidates.iter() {
+            let VideoSourceType::Local(camera) = candidate else {
+                continue;
+            };
+            if camera.name != source.name {
+                continue;
+            }
+            formats.insert(
+                candidate.inner().source_string().to_string(),
+                candidate.formats().await,
+            );
+        }
+
         match source
-            .try_identify_device(capture_configuration, candidates)
+            .try_identify_device(capture_configuration, candidates, &formats)
             .await
         {
             Ok(Some(candidate_source_string)) => {

--- a/src/lib/video/gst_device_monitor.rs
+++ b/src/lib/video/gst_device_monitor.rs
@@ -1,0 +1,111 @@
+use std::sync::{Arc, Mutex};
+
+use anyhow::{Context, Result};
+use gst_app::prelude::*;
+use tracing::*;
+
+lazy_static! {
+    static ref MANAGER: Arc<Mutex<Manager>> = {
+        // Constructing `gst::DeviceMonitor` requires GStreamer to be initialized; ensure it is so
+        // that callers like cameras_available() work even when the binary entry point hasn't run.
+        gst::init().expect("Failed to initialize GStreamer");
+        Arc::new(Mutex::new(Manager::default()))
+    };
+}
+
+#[derive(Default)]
+struct Manager {
+    monitor: gst::DeviceMonitor,
+}
+
+impl Drop for Manager {
+    fn drop(&mut self) {
+        self.monitor.stop();
+    }
+}
+
+#[instrument(level = "debug")]
+pub fn init() -> Result<()> {
+    let manager_guard = MANAGER.lock().unwrap();
+
+    manager_guard.monitor.set_show_all_devices(true);
+    manager_guard.monitor.set_show_all(true);
+    manager_guard.monitor.start()?;
+
+    let providers = manager_guard.monitor.providers();
+    info!("GST Device Providers: {providers:#?}");
+
+    Ok(())
+}
+
+#[instrument(level = "debug")]
+pub(crate) fn video_devices() -> Result<Vec<glib::WeakRef<gst::Device>>> {
+    let monitor = &MANAGER.lock().unwrap().monitor;
+
+    let devices = monitor
+        .devices()
+        .iter()
+        .filter_map(|device| {
+            if device.device_class().ne("Video/Source") {
+                return None;
+            }
+
+            Some(device.downgrade())
+        })
+        .collect();
+
+    Ok(devices)
+}
+
+#[instrument(level = "debug")]
+pub fn v4l_devices() -> Result<Vec<glib::WeakRef<gst::Device>>> {
+    let devices = video_devices()?
+        .iter()
+        .filter(|device_weak| {
+            let Some(device) = device_weak.upgrade() else {
+                return false;
+            };
+
+            device.properties().iter().any(|s| {
+                let Ok(api) = s.get::<String>("device.api") else {
+                    return false;
+                };
+
+                api.eq("v4l2")
+            })
+        })
+        .cloned()
+        .collect();
+
+    Ok(devices)
+}
+
+#[instrument(level = "debug")]
+pub fn v4l_device_with_path(device_path: &str) -> Result<glib::WeakRef<gst::Device>> {
+    v4l_devices()?
+        .iter()
+        .find(|device_weak| {
+            let Some(device) = device_weak.upgrade() else {
+                return false;
+            };
+
+            device.properties().iter().any(|s| {
+                let Ok(path) = s.get::<String>("device.path") else {
+                    return false;
+                };
+
+                path.eq(device_path)
+            })
+        })
+        .cloned()
+        .context("Device not found")
+}
+
+#[instrument(level = "debug")]
+pub fn device_caps(device: &glib::WeakRef<gst::Device>) -> Result<gst::Caps> {
+    device
+        .upgrade()
+        .context("Fail to access device")?
+        .caps()
+        .context("Caps not found")
+}

--- a/src/lib/video/local/video_source_local_linux.rs
+++ b/src/lib/video/local/video_source_local_linux.rs
@@ -3,6 +3,7 @@ use std::collections::HashMap;
 use std::sync::{Arc, Mutex};
 
 use anyhow::{Result, anyhow};
+use gst::prelude::*;
 use lazy_static::lazy_static;
 use paperclip::actix::Apiv2Schema;
 use regex::Regex;
@@ -13,6 +14,7 @@ use crate::{
     controls::types::*,
     stream::types::VideoCaptureConfiguration,
     video::{
+        gst_device_monitor,
         types::*,
         video_source::{VideoSource, VideoSourceAvailable, VideoSourceFormats},
     },
@@ -719,70 +721,24 @@ impl VideoSource for VideoSourceLocal {
 impl VideoSourceAvailable for VideoSourceLocal {
     #[instrument(level = "debug")]
     async fn cameras_available() -> Vec<VideoSourceType> {
-        let mut cameras: Vec<VideoSourceType> = vec![];
+        gst_device_monitor::v4l_devices()
+            .unwrap_or_default()
+            .iter()
+            .filter_map(|device_weak| {
+                let device = device_weak.upgrade()?;
+                let name = device.display_name().to_string();
+                let properties = device.properties()?;
+                let device_path = properties.get::<String>("device.path").ok()?;
+                let bus = properties.get::<String>("v4l2.device.bus_info").ok()?;
 
-        let cameras_path = {
-            let read_dir = match std::fs::read_dir("/dev/") {
-                Ok(cameras_path) => cameras_path,
-                Err(error) => {
-                    error!("Failed to get cameras from \"/dev/\": {error:?}");
-                    return cameras;
-                }
-            };
-
-            read_dir
-                .filter_map(|dir_entry| {
-                    let dir_entry = match dir_entry {
-                        Ok(dir_entry) => dir_entry,
-                        Err(error) => {
-                            debug!("Failed reading a device: {error:?}");
-                            return None;
-                        }
-                    };
-
-                    dir_entry.path().to_str().map(String::from)
-                })
-                .filter(|entry_str| entry_str.starts_with("/dev/video"))
-                .collect::<Vec<String>>()
-        };
-
-        for camera_path in &cameras_path {
-            let Ok(caps) = unpanic({
-                use v4l::video::Capture;
-
-                let camera_path = camera_path.clone();
-                move || {
-                    let v4l_device = v4l::Device::with_path(&camera_path).inspect_err(|error| {
-                        trace!("Failed to get device {camera_path:?}. Reason: {error:?}")
-                    })?;
-
-                    let caps = v4l_device.query_caps().inspect_err(|error| {
-                        trace!(
-                            "Failed to capture caps for device: {camera_path:?}. Reason: {error:?}"
-                        )
-                    })?;
-
-                    v4l_device.format().inspect_err(|error| {
-                        trace!("Failed to capture formats for device: {camera_path:?}. Reason: {error:?}")
-                    })?;
-
-                    Ok::<_, std::io::Error>(caps)
-                }
-            }) else {
-                continue;
-            };
-
-            let typ = VideoSourceLocalType::from_str(&caps.bus);
-
-            let source = VideoSourceLocal {
-                name: caps.card,
-                device_path: camera_path.to_string(),
-                typ,
-            };
-            cameras.push(VideoSourceType::Local(source));
-        }
-
-        cameras
+                let typ = VideoSourceLocalType::from_str(&bus);
+                Some(VideoSourceType::Local(VideoSourceLocal {
+                    name,
+                    device_path,
+                    typ,
+                }))
+            })
+            .collect()
     }
 }
 

--- a/src/lib/video/local/video_source_local_linux.rs
+++ b/src/lib/video/local/video_source_local_linux.rs
@@ -1,5 +1,8 @@
-use std::cmp::max;
-use std::collections::HashMap;
+use std::{
+    cmp::max,
+    collections::{HashMap, HashSet},
+    str::FromStr,
+};
 
 use anyhow::{Result, anyhow};
 use gst::prelude::*;
@@ -242,53 +245,301 @@ impl VideoSourceLocal {
     }
 }
 
-#[instrument(level = "debug")]
-fn convert_v4l_intervals(v4l_intervals: &[v4l::FrameInterval]) -> Vec<FrameInterval> {
-    let mut intervals: Vec<FrameInterval> = vec![];
+fn compute_intervals_from_range(
+    interval_start: FrameInterval,
+    interval_end: FrameInterval,
+    step: usize,
+) -> Vec<FrameInterval> {
+    let mut intervals = Vec::with_capacity(20);
 
-    v4l_intervals
-        .iter()
-        .for_each(|v4l_interval| match &v4l_interval.interval {
-            v4l::frameinterval::FrameIntervalEnum::Discrete(fraction) => {
-                intervals.push(FrameInterval {
-                    numerator: fraction.numerator,
-                    denominator: fraction.denominator,
-                })
-            }
-            v4l::frameinterval::FrameIntervalEnum::Stepwise(stepwise) => {
-                // To avoid a having a huge number of numerator/denominators, we
-                // arbitrarely set a minimum step of 5 units
-                let min_step = 5;
-                let numerator_step = max(stepwise.step.numerator, min_step);
-                let denominator_step = max(stepwise.step.denominator, min_step);
+    // To avoid having a huge number of numerator/denominators, we
+    // arbitrarily set a minimum step of 5 units
+    let step = step.max(5);
 
-                let numerators = (0..=stepwise.min.numerator)
-                    .step_by(numerator_step as usize)
-                    .chain(vec![stepwise.max.numerator])
-                    .collect::<Vec<u32>>();
-                let denominators = (0..=stepwise.min.denominator)
-                    .step_by(denominator_step as usize)
-                    .chain(vec![stepwise.max.denominator])
-                    .collect::<Vec<u32>>();
+    let numerator_end = interval_end.numerator.min(30);
+    let denominator_end = interval_end.denominator.min(30);
 
-                for numerator in &numerators {
-                    for denominator in &denominators {
-                        intervals.push(FrameInterval {
-                            numerator: max(1, *numerator),
-                            denominator: max(1, *denominator),
-                        });
-                    }
-                }
-            }
-        });
+    let min_numerator = max(1, interval_start.numerator);
+    let min_denominator = max(1, interval_start.denominator);
 
-    intervals.sort();
-    intervals.dedup();
-    intervals.reverse();
+    for numerator in (0..=numerator_end).step_by(step) {
+        for denominator in (0..=denominator_end).step_by(step) {
+            intervals.push(FrameInterval {
+                numerator: numerator.max(min_numerator),
+                denominator: denominator.max(min_denominator),
+            });
+        }
+    }
 
     intervals
 }
 
+impl From<gst::Fraction> for FrameInterval {
+    fn from(value: gst::Fraction) -> Self {
+        FrameInterval {
+            // Yes, our nominator is GST's denominator.
+            numerator: value.denom() as u32,
+            denominator: value.numer() as u32,
+        }
+    }
+}
+
+fn get_device_formats_using_gstreamer(
+    device_path: &str,
+    _typ: &VideoSourceLocalType,
+) -> Result<Vec<Format>> {
+    let device = gst_device_monitor::v4l_device_with_path(device_path)?;
+
+    let caps = gst_device_monitor::device_caps(&device)?;
+
+    let mut sizes_by_encode: HashMap<VideoEncodeType, HashSet<Size>> = HashMap::new();
+
+    caps.iter().for_each(|structure| {
+        let encodes: Vec<VideoEncodeType> = match structure.name().as_str() {
+            "video/x-raw" => match structure.value("format") {
+                Ok(sendvalue) => match sendvalue.type_().name() {
+                    "gchararray" => match sendvalue.get::<String>() {
+                        Ok(fourcc) => {
+                            vec![VideoEncodeType::from_str(&fourcc).expect("irrefutable")]
+                        }
+                        Err(error) => {
+                            warn!(
+                                "Failed reading video/x-raw format as gchararray: {structure:#?}: {error:?}"
+                            );
+                            return;
+                        }
+                    },
+                    "GstValueList" => match sendvalue.get::<gst::List>() {
+                        Ok(list) => list
+                            .iter()
+                            .filter_map(|v| v.get::<String>().ok())
+                            .map(|fourcc| VideoEncodeType::from_str(&fourcc).expect("irrefutable"))
+                            .collect(),
+                        Err(error) => {
+                            warn!(
+                                "Failed reading video/x-raw format as GstValueList: {structure:#?}: {error:?}"
+                            );
+                            return;
+                        }
+                    },
+                    unsupported_type => {
+                        info!(
+                            "video/x-raw format with unsupported type: {unsupported_type:?}: {structure:#?}"
+                        );
+                        return;
+                    }
+                },
+                Err(error) => {
+                    warn!("No format on video/x-raw: {structure:#?}: {error:?}");
+                    return;
+                }
+            },
+            "image/jpeg" => vec![VideoEncodeType::Mjpg],
+            "video/x-h264" => vec![VideoEncodeType::H264],
+            "video/x-h265" => vec![VideoEncodeType::H265],
+            other => {
+                info!("unknown format: {other:?}");
+
+                return;
+            }
+        };
+
+        let mut heights = match structure.value("height") {
+            Ok(sendvalue) => match sendvalue.type_().name() {
+                "gint" => match sendvalue.get::<i32>() {
+                    Ok(value) => vec![value as u32],
+                    Err(error) => {
+                        warn!("Failed reading height as gint: {structure:#?}: {error:?}");
+                        return;
+                    }
+                },
+                "GstIntRange" => {
+                    let range = match sendvalue.get::<gst::IntRange<i32>>() {
+                        Ok(range) => range,
+                        Err(error) => {
+                            warn!(
+                                "Failed reading height as GstIntRange: {structure:#?}: {error:?}"
+                            );
+                            return;
+                        }
+                    };
+
+                    let start = range.min() as u32;
+                    let end = range.max() as u32;
+                    let step = range.step() as u32;
+
+                    STANDARD_SIZES
+                        .iter()
+                        .filter_map(|(_, height)| {
+                            if height >= &start && height <= &end && (height % step == 0) {
+                                return Some(*height);
+                            }
+                            None
+                        })
+                        .collect::<Vec<_>>()
+                }
+                "GstValueList" => match sendvalue.get::<gst::List>() {
+                    Ok(list) => list
+                        .iter()
+                        .filter_map(|v| v.get::<i32>().ok().map(|value| value as u32))
+                        .collect::<Vec<_>>(),
+                    Err(error) => {
+                        warn!("Failed reading height as GstValueList: {structure:#?}: {error:?}");
+                        return;
+                    }
+                },
+                unsupported_type => {
+                    info!("Height with unsupported type: {unsupported_type:?}, {structure:#?}");
+                    return;
+                }
+            },
+            Err(error) => {
+                info!("No height: {structure:#?}: {error:?}");
+                return;
+            }
+        };
+
+        let mut widths = match structure.value("width") {
+            Ok(sendvalue) => match sendvalue.type_().name() {
+                "gint" => match sendvalue.get::<i32>() {
+                    Ok(value) => vec![value as u32],
+                    Err(error) => {
+                        warn!("Failed reading width as gint: {structure:#?}: {error:?}");
+                        return;
+                    }
+                },
+                "GstIntRange" => {
+                    let range = match sendvalue.get::<gst::IntRange<i32>>() {
+                        Ok(range) => range,
+                        Err(error) => {
+                            warn!("Failed reading width as GstIntRange: {structure:#?}: {error:?}");
+                            return;
+                        }
+                    };
+
+                    let start = range.min() as u32;
+                    let end = range.max() as u32;
+                    let step = range.step() as u32;
+
+                    STANDARD_SIZES
+                        .iter()
+                        .filter_map(|(width, _)| {
+                            if width >= &start && width <= &end && (width % step == 0) {
+                                return Some(*width);
+                            }
+                            None
+                        })
+                        .collect::<Vec<_>>()
+                }
+                "GstValueList" => match sendvalue.get::<gst::List>() {
+                    Ok(list) => list
+                        .iter()
+                        .filter_map(|v| v.get::<i32>().ok().map(|value| value as u32))
+                        .collect::<Vec<_>>(),
+                    Err(error) => {
+                        warn!("Failed reading width as GstValueList: {structure:#?}: {error:?}");
+                        return;
+                    }
+                },
+                unsupported_type => {
+                    info!("Width with unsupported type: {unsupported_type:?}, {structure:#?}");
+                    return;
+                }
+            },
+            Err(error) => {
+                info!("No width: {structure:#?}: {error:?}");
+                return;
+            }
+        };
+
+        let mut intervals = match structure.value("framerate") {
+            Ok(sendvalue) => match sendvalue.type_().name() {
+                "GstFraction" => match sendvalue.get::<gst::Fraction>() {
+                    Ok(fraction) => vec![fraction.into()],
+                    Err(error) => {
+                        warn!(
+                            "Failed reading framerate as GstFraction: {structure:#?}: {error:?}"
+                        );
+                        return;
+                    }
+                },
+                "GstFractionRange" => {
+                    let range = match sendvalue.get::<gst::FractionRange>() {
+                        Ok(range) => range,
+                        Err(error) => {
+                            warn!(
+                                "Failed reading framerate as GstFractionRange: {structure:#?}: {error:?}"
+                            );
+                            return;
+                        }
+                    };
+
+                    compute_intervals_from_range(range.min().into(), range.max().into(), 1)
+                }
+                "GstValueList" => match sendvalue.get::<gst::List>() {
+                    Ok(list) => list
+                        .iter()
+                        .filter_map(|sendvalue| {
+                            sendvalue.get::<gst::Fraction>().ok().map(Into::into)
+                        })
+                        .collect::<Vec<_>>(),
+                    Err(error) => {
+                        warn!(
+                            "Failed reading framerate as GstValueList: {structure:#?}: {error:?}"
+                        );
+                        return;
+                    }
+                },
+                unsupported_type => {
+                    info!("Framerate with unsupported type: {unsupported_type:?}, {structure:#?}");
+                    return;
+                }
+            },
+            Err(error) => {
+                info!("No framerate: {structure:#?}: {error:?}");
+                return;
+            }
+        };
+
+        heights.sort();
+        heights.dedup();
+
+        widths.sort();
+        widths.dedup();
+
+        intervals.sort();
+        intervals.dedup();
+        intervals.reverse();
+
+        widths.into_iter().zip(heights).for_each(|(width, height)| {
+            let size = Size {
+                width,
+                height,
+                intervals: intervals.clone(),
+            };
+
+            for encode in &encodes {
+                sizes_by_encode
+                    .entry(encode.clone())
+                    .or_default()
+                    .insert(size.clone());
+            }
+        });
+    });
+
+    let mut formats = Vec::with_capacity(sizes_by_encode.len());
+
+    sizes_by_encode.into_iter().for_each(|(encode, sizes)| {
+        let mut sizes = sizes.into_iter().collect::<Vec<Size>>();
+        sizes.sort();
+        // sizes.dedup();
+        sizes.reverse();
+
+        formats.push(Format { encode, sizes })
+    });
+
+    Ok(formats)
+}
 #[instrument(level = "debug")]
 fn validate_control(control: &Control, value: i64) -> Result<(), String> {
     if control.state.is_inactive {
@@ -335,150 +586,16 @@ fn validate_control(control: &Control, value: i64) -> Result<(), String> {
 impl VideoSourceFormats for VideoSourceLocal {
     #[instrument(level = "debug")]
     async fn formats(&self) -> Vec<Format> {
-        let device_path = self.device_path.clone();
-        let typ = self.typ.clone();
+        let device_path = &self.device_path;
+        let typ = &self.typ;
 
-        unpanic(move || {
-            let mut formats = vec![];
-
-            let v4l_device = match v4l::Device::with_path(&device_path) {
-                Ok(device) => device,
-                Err(error) => {
-                    trace!("Faield to get device {device_path:?}: {error:?}");
-                    return formats;
-                }
-            };
-
-            use v4l::video::Capture;
-
-            let v4l_formats = v4l_device.enum_formats().unwrap_or_default();
-            trace!("Checking resolutions for camera {device_path:?}");
-            for v4l_format in v4l_formats {
-                let mut sizes = vec![];
-                let mut errors: Vec<String> = vec![];
-
-                let v4l_framesizes = match v4l_device.enum_framesizes(v4l_format.fourcc) {
-                    Ok(v4l_framesizes) => v4l_framesizes,
-                    Err(error) => {
-                        trace!(
-                            "Failed to get framesizes from format {v4l_format:?} for device {device_path:?}: {error:#?}"
-                        );
-                        continue;
-                    }
-                };
-
-                for v4l_framesize in v4l_framesizes {
-                    match v4l_framesize.size {
-                        v4l::framesize::FrameSizeEnum::Discrete(v4l_size) => {
-                            match &v4l_device.enum_frameintervals(
-                                v4l_framesize.fourcc,
-                                v4l_size.width,
-                                v4l_size.height,
-                            ) {
-                                Ok(enum_frameintervals) => {
-                                    let intervals = convert_v4l_intervals(enum_frameintervals);
-                                    sizes.push(Size {
-                                        width: v4l_size.width,
-                                        height: v4l_size.height,
-                                        intervals,
-                                    })
-                                }
-                                Err(error) => {
-                                    errors.push(format!(
-                                        "encode: {encode:?}, for size: {v4l_size:?}, error: {error:#?}",
-                                        encode = v4l_format.fourcc,
-                                    ));
-                                }
-                            }
-                        }
-                        v4l::framesize::FrameSizeEnum::Stepwise(v4l_size) => {
-                            let mut std_sizes: Vec<(u32, u32)> = STANDARD_SIZES.to_vec();
-                            std_sizes.push((v4l_size.max_width, v4l_size.max_height));
-
-                            std_sizes.iter().for_each(|(width, height)| {
-                                match &v4l_device.enum_frameintervals(v4l_framesize.fourcc, *width, *height) {
-                                    Ok(enum_frameintervals) => {
-                                        let intervals = convert_v4l_intervals(enum_frameintervals);
-                                        sizes.push(Size {
-                                            width: *width,
-                                            height: *height,
-                                            intervals,
-                                        });
-                                    }
-                                    Err(error) => {
-                                        errors.push(format!(
-                                            "encode: {encode:?}, for size: {v4l_size:?}, error: {error:#?}",
-                                            encode = v4l_format.fourcc,
-                                            v4l_size = (width, height),
-                                        ));
-                                    }
-                                };
-                            });
-                        }
-                    }
-                }
-
-                sizes.sort();
-                sizes.dedup();
-                sizes.reverse();
-
-                if !errors.is_empty() {
-                    trace!("Failed to fetch frameintervals for camera {device_path}: {errors:#?}");
-                }
-
-                match v4l_format.fourcc.str() {
-                    Ok(encode_str) => {
-                        formats.push(Format {
-                            encode: encode_str.parse().unwrap(),
-                            sizes,
-                        });
-                    }
-                    Err(error) => warn!(
-                        "Failed to represent fourcc {:?} as a string: {error:?}",
-                        v4l_format.fourcc
-                    ),
-                }
+        return match get_device_formats_using_gstreamer(device_path, typ) {
+            Ok(devices) => devices,
+            Err(error) => {
+                warn!("Failed getting formats for device {device_path:?}: {error:?}");
+                vec![]
             }
-            // V4l2 reports unsupported sizes for Raspberry Pi
-            // Cameras in Legacy Mode, showing the following:
-            // > mmal: mmal_vc_port_enable: failed to enable port vc.ril.video_encode:in:0(OPQV): EINVAL
-            // > mmal: mmal_port_enable: failed to enable connected port (vc.ril.video_encode:in:0(OPQV))0x75903be0 (EINVAL)
-            // > mmal: mmal_connection_enable: output port couldn't be enabled
-            // To prevent it, we are currently constraining it
-            // to a max. of 1920 x 1080 px, and a max. 30 FPS.
-            if matches!(typ, VideoSourceLocalType::LegacyRpiCam(_)) {
-                warn!(
-                    "To support Raspiberry Pi Cameras in Legacy Camera Mode without bugs, resolution is constrained to 1920 x 1080 @ 30 FPS."
-                );
-                let max_width = 1920;
-                let max_height = 1080;
-                let max_fps = 30;
-                formats.iter_mut().for_each(|format| {
-                    format.sizes.iter_mut().for_each(|size| {
-                        if size.width > max_width {
-                            size.width = max_width;
-                        }
-
-                        if size.height > max_height {
-                            size.height = max_height;
-                        }
-
-                        size.intervals = size
-                            .intervals
-                            .clone()
-                            .into_iter()
-                            .filter(|interval| interval.numerator * interval.denominator <= max_fps)
-                            .collect();
-                    });
-
-                    format.sizes.dedup();
-                });
-            }
-            formats.sort();
-            formats.dedup();
-
-            formats
-        })
+        };
     }
 }
 

--- a/src/lib/video/local/video_source_local_linux.rs
+++ b/src/lib/video/local/video_source_local_linux.rs
@@ -1,10 +1,8 @@
 use std::cmp::max;
 use std::collections::HashMap;
-use std::sync::{Arc, Mutex};
 
 use anyhow::{Result, anyhow};
 use gst::prelude::*;
-use lazy_static::lazy_static;
 use paperclip::actix::Apiv2Schema;
 use regex::Regex;
 use serde::{Deserialize, Serialize};
@@ -19,10 +17,6 @@ use crate::{
         video_source::{VideoSource, VideoSourceAvailable, VideoSourceFormats},
     },
 };
-
-lazy_static! {
-    static ref VIDEO_FORMATS: Arc<Mutex<HashMap<String, Vec<Format>>>> = Default::default();
-}
 
 /// Helper function to wrap calls from v4l that can cause panic, returning an error instead
 fn unpanic<T, F>(body: F) -> T
@@ -127,11 +121,12 @@ impl VideoSourceLocalType {
 }
 
 impl VideoSourceLocal {
-    #[instrument(level = "debug")]
+    #[instrument(level = "debug", skip(formats))]
     pub async fn try_identify_device(
         &mut self,
         capture_configuration: &VideoCaptureConfiguration,
         candidates: &[VideoSourceType],
+        formats: &HashMap<String, Vec<Format>>,
     ) -> Result<Option<String>> {
         // Rule n.1 - All candidates must share the same camera name
         let candidates = Self::get_cameras_with_same_name(candidates, &self.name);
@@ -145,7 +140,7 @@ impl VideoSourceLocal {
 
         // Rule n.2 - All candidates must share the same encode
         let candidates =
-            Self::get_cameras_with_same_encode(&candidates, &capture_configuration.encode).await;
+            Self::get_cameras_with_same_encode(&candidates, &capture_configuration.encode, formats);
 
         let len = candidates.len();
         if len == 0 {
@@ -212,25 +207,21 @@ impl VideoSourceLocal {
             .collect()
     }
 
-    #[instrument(level = "debug")]
-    async fn get_cameras_with_same_encode(
+    #[instrument(level = "debug", skip(formats))]
+    fn get_cameras_with_same_encode(
         candidates: &[VideoSourceType],
         encode: &VideoEncodeType,
+        formats: &HashMap<String, Vec<Format>>,
     ) -> Vec<VideoSourceType> {
-        let mut result = Vec::new();
-
-        for candidate in candidates.iter() {
-            if candidate
-                .formats()
-                .await
-                .iter()
-                .any(|format| &format.encode == encode)
-            {
-                result.push(candidate.clone());
-            }
-        }
-
-        result
+        candidates
+            .iter()
+            .filter(|candidate| {
+                formats
+                    .get(candidate.inner().source_string())
+                    .is_some_and(|fs| fs.iter().any(|format| &format.encode == encode))
+            })
+            .cloned()
+            .collect()
     }
 
     #[instrument(level = "debug")]
@@ -348,10 +339,6 @@ impl VideoSourceFormats for VideoSourceLocal {
         let typ = self.typ.clone();
 
         unpanic(move || {
-            if let Some(formats) = VIDEO_FORMATS.lock().unwrap().get(&device_path) {
-                return formats.clone();
-            }
-
             let mut formats = vec![];
 
             let v4l_device = match v4l::Device::with_path(&device_path) {
@@ -490,10 +477,6 @@ impl VideoSourceFormats for VideoSourceLocal {
             formats.sort();
             formats.dedup();
 
-            VIDEO_FORMATS
-                .lock()
-                .unwrap()
-                .insert(device_path.to_string(), formats.clone());
             formats
         })
     }
@@ -788,7 +771,6 @@ mod tests {
 
 #[cfg(test)]
 mod device_identification_tests {
-    use serial_test::serial;
     use tracing_test::traced_test;
 
     use super::*;
@@ -799,14 +781,19 @@ mod device_identification_tests {
     use VideoEncodeType::*;
 
     #[instrument(level = "debug")]
-    fn add_available_camera(
-        name: &str,
-        device_path: &str,
-        usb_bus: &str,
-        encodes: Vec<VideoEncodeType>,
-    ) -> VideoSourceType {
-        let formats = encodes
-            .into_iter()
+    fn add_available_camera(name: &str, device_path: &str, usb_bus: &str) -> VideoSourceType {
+        VideoSourceType::Local(VideoSourceLocal {
+            name: name.into(),
+            device_path: device_path.into(),
+            typ: VideoSourceLocalType::Usb(usb_bus.into()),
+        })
+    }
+
+    #[instrument(level = "debug")]
+    fn formats_for(encodes: &[VideoEncodeType]) -> Vec<Format> {
+        encodes
+            .iter()
+            .cloned()
             .map(|encode| Format {
                 encode,
                 sizes: vec![Size {
@@ -818,19 +805,7 @@ mod device_identification_tests {
                     }],
                 }],
             })
-            .collect::<Vec<Format>>();
-
-        // Register its formats
-        VIDEO_FORMATS
-            .lock()
-            .unwrap()
-            .insert(device_path.to_string(), formats);
-
-        VideoSourceType::Local(VideoSourceLocal {
-            name: name.into(),
-            device_path: device_path.into(),
-            typ: VideoSourceLocalType::Usb(usb_bus.into()),
-        })
+            .collect()
     }
 
     #[instrument(level = "debug")]
@@ -863,58 +838,52 @@ mod device_identification_tests {
         }
     }
 
-    #[serial]
     #[traced_test]
     #[tokio::test]
     async fn test_get_cameras_with_same_name() {
-        VIDEO_FORMATS.lock().unwrap().clear();
-
         let candidates = vec![
-            add_available_camera("A", "/dev/video0", "usb_port_0", vec![H264]),
-            add_available_camera("A", "/dev/video1", "usb_port_0", vec![Yuyv, Mjpg]),
-            add_available_camera("A", "/dev/video2", "usb_port_1", vec![H264]),
-            add_available_camera("A", "/dev/video3", "usb_port_1", vec![Yuyv, Mjpg]),
-            add_available_camera("B", "/dev/video4", "usb_port_2", vec![H264]),
-            add_available_camera("B", "/dev/video5", "usb_port_2", vec![Yuyv, Mjpg]),
+            add_available_camera("A", "/dev/video0", "usb_port_0"),
+            add_available_camera("A", "/dev/video1", "usb_port_0"),
+            add_available_camera("A", "/dev/video2", "usb_port_1"),
+            add_available_camera("A", "/dev/video3", "usb_port_1"),
+            add_available_camera("B", "/dev/video4", "usb_port_2"),
+            add_available_camera("B", "/dev/video5", "usb_port_2"),
         ];
 
         let same_name_candidates = VideoSourceLocal::get_cameras_with_same_name(&candidates, "A");
         assert_eq!(candidates[..4].to_vec(), same_name_candidates);
-
-        VIDEO_FORMATS.lock().unwrap().clear();
     }
 
-    #[serial]
     #[traced_test]
     #[tokio::test]
     async fn test_get_cameras_with_same_encode() {
-        VIDEO_FORMATS.lock().unwrap().clear();
-
         let candidates = vec![
-            add_available_camera("A", "/dev/video0", "usb_port_0", vec![H264]),
-            add_available_camera("B", "/dev/video1", "usb_port_1", vec![H264]),
-            add_available_camera("C", "/dev/video2", "usb_port_0", vec![Yuyv, Mjpg]),
-            add_available_camera("D", "/dev/video3", "usb_port_1", vec![Yuyv, Mjpg]),
+            add_available_camera("A", "/dev/video0", "usb_port_0"),
+            add_available_camera("B", "/dev/video1", "usb_port_1"),
+            add_available_camera("C", "/dev/video2", "usb_port_0"),
+            add_available_camera("D", "/dev/video3", "usb_port_1"),
         ];
 
-        let same_encode_candidates =
-            VideoSourceLocal::get_cameras_with_same_encode(&candidates, &H264).await;
-        assert_eq!(candidates[..2].to_vec(), same_encode_candidates);
+        let formats = HashMap::from([
+            ("/dev/video0".into(), formats_for(&[H264])),
+            ("/dev/video1".into(), formats_for(&[H264])),
+            ("/dev/video2".into(), formats_for(&[Yuyv, Mjpg])),
+            ("/dev/video3".into(), formats_for(&[Yuyv, Mjpg])),
+        ]);
 
-        VIDEO_FORMATS.lock().unwrap().clear();
+        let same_encode_candidates =
+            VideoSourceLocal::get_cameras_with_same_encode(&candidates, &H264, &formats);
+        assert_eq!(candidates[..2].to_vec(), same_encode_candidates);
     }
 
-    #[serial]
     #[traced_test]
     #[tokio::test]
     async fn test_get_cameras_with_same_bus() {
-        VIDEO_FORMATS.lock().unwrap().clear();
-
         let candidates = vec![
-            add_available_camera("A", "/dev/video0", "usb_port_0", vec![H264]),
-            add_available_camera("B", "/dev/video1", "usb_port_0", vec![Yuyv, Mjpg]),
-            add_available_camera("C", "/dev/video2", "usb_port_1", vec![H264]),
-            add_available_camera("D", "/dev/video3", "usb_port_1", vec![Yuyv, Mjpg]),
+            add_available_camera("A", "/dev/video0", "usb_port_0"),
+            add_available_camera("B", "/dev/video1", "usb_port_0"),
+            add_available_camera("C", "/dev/video2", "usb_port_1"),
+            add_available_camera("D", "/dev/video3", "usb_port_1"),
         ];
 
         let same_encode_candidates = VideoSourceLocal::get_cameras_with_same_bus(
@@ -922,24 +891,27 @@ mod device_identification_tests {
             &VideoSourceLocalType::Usb("usb_port_0".into()),
         );
         assert_eq!(candidates[..2].to_vec(), same_encode_candidates);
-
-        VIDEO_FORMATS.lock().unwrap().clear();
     }
 
-    // #[traced_test]
-    #[serial]
     #[traced_test]
     #[tokio::test]
     async fn identify_a_candidate_with_same_name_and_encode() {
-        VIDEO_FORMATS.lock().unwrap().clear();
-
         let candidates = vec![
-            add_available_camera("A", "/dev/video0", "usb_port_0", vec![H264]),
-            add_available_camera("A", "/dev/video1", "usb_port_0", vec![Yuyv, Mjpg]),
-            add_available_camera("B", "/dev/video2", "usb_port_1", vec![H264]),
-            add_available_camera("B", "/dev/video3", "usb_port_1", vec![Yuyv, Mjpg]),
-            add_available_camera("C", "/dev/video3", "usb_port_1", vec![H264, Yuyv, Mjpg]),
+            add_available_camera("A", "/dev/video0", "usb_port_0"),
+            add_available_camera("A", "/dev/video1", "usb_port_0"),
+            add_available_camera("B", "/dev/video2", "usb_port_1"),
+            add_available_camera("B", "/dev/video3", "usb_port_1"),
+            add_available_camera("C", "/dev/video3", "usb_port_1"),
         ];
+        let formats = HashMap::from([
+            ("/dev/video0".into(), formats_for(&[H264])),
+            ("/dev/video1".into(), formats_for(&[Yuyv, Mjpg])),
+            ("/dev/video2".into(), formats_for(&[H264])),
+            // /dev/video3 is shared between B and C in the original test; only the encodes
+            // for B's entry are exercised here (C is filtered out by name first).
+            ("/dev/video3".into(), formats_for(&[Yuyv, Mjpg])),
+        ]);
+
         let stream = create_stream("A", "/dev/video0", "usb_port_0", H264);
         let (VideoSourceType::Local(source), CaptureConfiguration::Video(capture_configuration)) = (
             &stream.video_source,
@@ -950,7 +922,7 @@ mod device_identification_tests {
 
         let Ok(Some(candidate_source_string)) = source
             .to_owned()
-            .try_identify_device(capture_configuration, &candidates)
+            .try_identify_device(capture_configuration, &candidates, &formats)
             .await
         else {
             panic!("Failed to identify the only device with the same name and encode")
@@ -961,33 +933,33 @@ mod device_identification_tests {
             stream.video_source.inner().source_string().to_string()
         );
 
-        // IF we remove the only device with the same name and encode, we should get an error
+        // If we remove the only device with the same name and encode, we should get an error
         source
             .to_owned()
-            .try_identify_device(capture_configuration, &candidates[1..])
+            .try_identify_device(capture_configuration, &candidates[1..], &formats)
             .await
             .expect_err("Failed to identify the only device with the same name and encode");
-
-        VIDEO_FORMATS.lock().unwrap().clear();
     }
 
-    // #[traced_test]
-    #[serial]
     #[traced_test]
     #[tokio::test]
     async fn identify_a_candidate_when_usb_port_changed() {
-        VIDEO_FORMATS.lock().unwrap().clear();
-
         // Before this boot, the device candidates[0] was in "usb_port_0" and the device candidates[1] was in "usb_port_1":
         let last_usb_bus = "usb_port_1";
         let current_usb_bus = "usb_port_0";
 
         let candidates = vec![
-            add_available_camera("A", "/dev/video0", current_usb_bus, vec![H264]),
-            add_available_camera("A", "/dev/video1", current_usb_bus, vec![Yuyv, Mjpg]),
-            add_available_camera("B", "/dev/video2", "usb_port_3", vec![H264]),
-            add_available_camera("B", "/dev/video3", "usb_port_3", vec![Yuyv, Mjpg]),
+            add_available_camera("A", "/dev/video0", current_usb_bus),
+            add_available_camera("A", "/dev/video1", current_usb_bus),
+            add_available_camera("B", "/dev/video2", "usb_port_3"),
+            add_available_camera("B", "/dev/video3", "usb_port_3"),
         ];
+        let formats = HashMap::from([
+            ("/dev/video0".into(), formats_for(&[H264])),
+            ("/dev/video1".into(), formats_for(&[Yuyv, Mjpg])),
+            ("/dev/video2".into(), formats_for(&[H264])),
+            ("/dev/video3".into(), formats_for(&[Yuyv, Mjpg])),
+        ]);
 
         for n in (0..3).collect::<Vec<_>>() {
             let stream = create_stream("A", &format!("/dev/video{n}"), last_usb_bus, H264);
@@ -1004,7 +976,7 @@ mod device_identification_tests {
 
             let Ok(Some(candidate_source_string)) = source
                 .to_owned()
-                .try_identify_device(capture_configuration, &candidates)
+                .try_identify_device(capture_configuration, &candidates, &formats)
                 .await
             else {
                 panic!("Failed to identify the only device with the same name and encode")
@@ -1019,31 +991,31 @@ mod device_identification_tests {
             other_candidates.remove(0);
             source
                 .to_owned()
-                .try_identify_device(capture_configuration, &other_candidates)
+                .try_identify_device(capture_configuration, &other_candidates, &formats)
                 .await
                 .expect_err("Failed to identify the only device with the same name and encode");
         }
-
-        VIDEO_FORMATS.lock().unwrap().clear();
     }
 
-    // #[traced_test]
-    #[serial]
     #[traced_test]
     #[tokio::test]
     async fn identify_a_candidate_when_path_changed() {
-        VIDEO_FORMATS.lock().unwrap().clear();
-
         // Before this boot, the device candidates[0] was in "/dev/video1" and the device candidates[1] was in "/dev/video0":
         let last_path = "/dev/video1";
         let current_path = "/dev/video0";
 
         let candidates = vec![
-            add_available_camera("A", current_path, "usb_port_0", vec![H264]),
-            add_available_camera("A", last_path, "usb_port_1", vec![H264]),
-            add_available_camera("A", "/dev/video3", "usb_port_0", vec![Yuyv, Mjpg]),
-            add_available_camera("A", "/dev/video5", "usb_port_1", vec![Yuyv, Mjpg]),
+            add_available_camera("A", current_path, "usb_port_0"),
+            add_available_camera("A", last_path, "usb_port_1"),
+            add_available_camera("A", "/dev/video3", "usb_port_0"),
+            add_available_camera("A", "/dev/video5", "usb_port_1"),
         ];
+        let formats = HashMap::from([
+            (current_path.into(), formats_for(&[H264])),
+            (last_path.into(), formats_for(&[H264])),
+            ("/dev/video3".into(), formats_for(&[Yuyv, Mjpg])),
+            ("/dev/video5".into(), formats_for(&[Yuyv, Mjpg])),
+        ]);
 
         for n in (0..=1).collect::<Vec<_>>() {
             let stream = create_stream("A", last_path, &format!("usb_port_{n}"), H264);
@@ -1061,7 +1033,7 @@ mod device_identification_tests {
 
             let Ok(Some(candidate_source_string)) = source
                 .to_owned()
-                .try_identify_device(capture_configuration, &candidates)
+                .try_identify_device(capture_configuration, &candidates, &formats)
                 .await
             else {
                 panic!("Failed to identify the only device with the same name and encode")
@@ -1071,27 +1043,27 @@ mod device_identification_tests {
                 candidates[n].inner().source_string()
             );
         }
-
-        VIDEO_FORMATS.lock().unwrap().clear();
     }
 
-    // #[traced_test]
-    #[serial]
     #[traced_test]
     #[tokio::test]
     async fn do_not_identify_if_several_devices_with_same_name_and_encode() {
-        VIDEO_FORMATS.lock().unwrap().clear();
-
         // Before this boot, the device candidates[0] was in "usb_port_0" and the device candidates[1] was in "usb_port_1":
         let last_usb_bus = "usb_port_1";
         let current_usb_bus = "usb_port_0";
 
         let candidates = vec![
-            add_available_camera("A", "/dev/video0", current_usb_bus, vec![H264]),
-            add_available_camera("A", "/dev/video1", current_usb_bus, vec![Yuyv, Mjpg]),
-            add_available_camera("A", "/dev/video4", "usb_port_2", vec![H264]),
-            add_available_camera("A", "/dev/video5", "usb_port_2", vec![Yuyv, Mjpg]),
+            add_available_camera("A", "/dev/video0", current_usb_bus),
+            add_available_camera("A", "/dev/video1", current_usb_bus),
+            add_available_camera("A", "/dev/video4", "usb_port_2"),
+            add_available_camera("A", "/dev/video5", "usb_port_2"),
         ];
+        let formats = HashMap::from([
+            ("/dev/video0".into(), formats_for(&[H264])),
+            ("/dev/video1".into(), formats_for(&[Yuyv, Mjpg])),
+            ("/dev/video4".into(), formats_for(&[H264])),
+            ("/dev/video5".into(), formats_for(&[Yuyv, Mjpg])),
+        ]);
 
         for n in (0..5).collect::<Vec<_>>() {
             let stream = create_stream("A", &format!("/dev/video{n}"), last_usb_bus, H264);
@@ -1109,13 +1081,11 @@ mod device_identification_tests {
             assert!(
                 source
                     .to_owned()
-                    .try_identify_device(capture_configuration, &candidates)
+                    .try_identify_device(capture_configuration, &candidates, &formats)
                     .await
                     .expect("Failed to identify the only device with the same name and encode")
                     .is_none()
             )
         }
-
-        VIDEO_FORMATS.lock().unwrap().clear();
     }
 }

--- a/src/lib/video/local/video_source_local_none.rs
+++ b/src/lib/video/local/video_source_local_none.rs
@@ -1,3 +1,5 @@
+use std::collections::HashMap;
+
 use anyhow::Result;
 use paperclip::actix::Apiv2Schema;
 use serde::{Deserialize, Serialize};
@@ -23,8 +25,9 @@ pub struct VideoSourceLocal {
 impl VideoSourceLocal {
     pub async fn try_identify_device(
         &mut self,
-        capture_configuration: &VideoCaptureConfiguration,
-        candidates: &[VideoSourceType],
+        _capture_configuration: &VideoCaptureConfiguration,
+        _candidates: &[VideoSourceType],
+        _formats: &HashMap<String, Vec<Format>>,
     ) -> Result<Option<String>> {
         Ok(None)
     }

--- a/src/lib/video/mod.rs
+++ b/src/lib/video/mod.rs
@@ -8,3 +8,5 @@ pub mod video_source_gst;
 pub mod video_source_local;
 pub mod video_source_onvif;
 pub mod video_source_redirect;
+
+pub mod gst_device_monitor;

--- a/src/lib/video/types.rs
+++ b/src/lib/video/types.rs
@@ -1,4 +1,3 @@
-use gst;
 use paperclip::actix::Apiv2Schema;
 use serde::{Deserialize, Serialize};
 
@@ -18,7 +17,17 @@ pub enum VideoSourceType {
     Redirect(VideoSourceRedirect),
 }
 
-#[derive(Apiv2Schema, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Deserialize, Serialize)]
+#[derive(
+    Apiv2Schema, Clone, Debug, PartialEq, Eq, PartialOrd, Ord, Deserialize, Serialize, Hash,
+)]
+pub struct Format {
+    pub encode: VideoEncodeType,
+    pub sizes: Vec<Size>,
+}
+
+#[derive(
+    Apiv2Schema, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Deserialize, Serialize, Hash,
+)]
 #[serde(rename_all = "UPPERCASE")]
 pub enum VideoEncodeType {
     H264,
@@ -29,32 +38,21 @@ pub enum VideoEncodeType {
     Yuyv,
 }
 
-#[derive(Apiv2Schema, Clone, Debug, PartialEq, Eq, PartialOrd, Ord, Deserialize, Serialize)]
-pub struct Format {
-    pub encode: VideoEncodeType,
-    pub sizes: Vec<Size>,
-}
-
-#[derive(Apiv2Schema, Clone, Debug, PartialEq, Eq, PartialOrd, Ord, Deserialize, Serialize)]
+#[derive(
+    Apiv2Schema, Clone, Debug, PartialEq, Eq, PartialOrd, Ord, Deserialize, Serialize, Hash,
+)]
 pub struct Size {
     pub width: u32,
     pub height: u32,
     pub intervals: Vec<FrameInterval>,
 }
 
-#[derive(Apiv2Schema, Clone, Debug, PartialEq, Eq, PartialOrd, Ord, Deserialize, Serialize)]
+#[derive(
+    Apiv2Schema, Clone, Debug, PartialEq, Eq, PartialOrd, Ord, Deserialize, Serialize, Hash,
+)]
 pub struct FrameInterval {
     pub numerator: u32,
     pub denominator: u32,
-}
-
-impl From<gst::Fraction> for FrameInterval {
-    fn from(fraction: gst::Fraction) -> Self {
-        FrameInterval {
-            numerator: fraction.numer() as u32,
-            denominator: fraction.denom() as u32,
-        }
-    }
 }
 
 impl VideoSourceType {
@@ -88,7 +86,7 @@ impl std::str::FromStr for VideoEncodeType {
             "H264" => VideoEncodeType::H264,
             "H265" | "HEVC" => VideoEncodeType::H265,
             "MJPG" => VideoEncodeType::Mjpg,
-            "YUYV" => VideoEncodeType::Yuyv,
+            "YUYV" | "YUY2" => VideoEncodeType::Yuyv,
             _ => VideoEncodeType::Unknown(fourcc),
         };
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -29,6 +29,8 @@ async fn async_main() -> Result<(), std::io::Error> {
 
     stream::gst::utils::check_all_plugins().unwrap();
 
+    mavlink_camera_manager::video::gst_device_monitor::init().unwrap();
+
     mavlink::manager::Manager::init();
 
     stream::manager::init();


### PR DESCRIPTION
Merge after #607 

### update 13/05/26:

This PR is the first step towards supporting libcamera. In this step, we move from the v4l crate to give us the stream formats to get them from the GStreamer DeviceMonitor.

The further steps are already planned, and libcamera will be functional in the next PR.

With these changes, the v4l crate is only used for the controls API (which is fine).

---

### update 09/29/25:

This seems very promising -- so far, I have already replaced the v4l formats and the v4l device discovery.

I'm thinking we should refactor the source/pipeline part of the application to fully make use of this Device Monitor:

1. I still need to reason about the architecture, but I think we can safely say that at least we should split our "Pipelines" (v4l2_pipeline.rs, etc) into a source (pipeline: source -> capsfilter -> parser -> proxysink) + transcoding pipeline (pipeline: proxysrc -> video_tee -> rtp_payloader -> capsfilter -> rtp_tee, as well as the future optional decoder+encoder), which will then connect to our many sink (pipeline: proxysrc -> sink).
2. Then we create a Device enum (w/ VideoSource and AudioSource variants) and a DeviceProvider trait, implemented by both this GSTDeviceMonitor and by the OnvifDiscovery, to give us a common interface.
3. Each "gst::Device" is also an element factory provider, which allows you to create its source element with no effort, which will help us to more easily reach libcamera and audio support.

---

Helps #372, #273, #139, #79