### PR TITLE
Fix thread leak

### DIFF
--- a/src/stream/manager.rs
+++ b/src/stream/manager.rs
@@ -40,7 +40,7 @@ pub struct Manager {
 }
 
 lazy_static! {
-    static ref MANAGER: Arc<Mutex<Manager>> = Arc::new(Mutex::new(Manager::default()));
+    static ref MANAGER: Arc<Mutex<Manager>> = Default::default();
 }
 
 impl Manager {

--- a/src/stream/manager.rs
+++ b/src/stream/manager.rs
@@ -272,6 +272,14 @@ pub async fn get_jpeg_thumbnail_from_source(
     let (tx, rx) = tokio::sync::oneshot::channel();
     std::thread::spawn(move || {
         tokio::runtime::Builder::new_current_thread()
+            .on_thread_start(|| debug!("Thread started"))
+            .on_thread_stop(|| debug!("Thread stopped"))
+            .thread_name_fn(|| {
+                static ATOMIC_ID: std::sync::atomic::AtomicUsize =
+                    std::sync::atomic::AtomicUsize::new(0);
+                let id = ATOMIC_ID.fetch_add(1, std::sync::atomic::Ordering::SeqCst);
+                format!("Thumbnailer-{id}")
+            })
             .enable_time()
             .build()
             .expect("Failed building a new tokio runtime")

--- a/src/stream/manager.rs
+++ b/src/stream/manager.rs
@@ -29,7 +29,6 @@ use super::{
         self,
         signalling_protocol::RTCSessionDescription,
         signalling_server::{StreamManagementInterface, WebRTCSessionManagementInterface},
-        webrtcbin_interface::WebRTCBinInterface,
     },
     Stream,
 };

--- a/src/stream/sink/webrtc_sink.rs
+++ b/src/stream/sink/webrtc_sink.rs
@@ -1,7 +1,5 @@
-use std::sync::{Arc, Mutex};
-
 use anyhow::{anyhow, Context, Result};
-use tokio::sync::mpsc;
+use tokio::sync::mpsc::{self, WeakUnboundedSender};
 use tracing::*;
 
 use gst::prelude::*;
@@ -9,34 +7,29 @@ use gst::prelude::*;
 use super::SinkInterface;
 use crate::stream::manager::Manager;
 use crate::stream::webrtc::signalling_protocol::{
-    Answer, BindAnswer, EndSessionQuestion, IceNegotiation, MediaNegotiation, Message, Question,
-    RTCIceCandidateInit, RTCSessionDescription, Sdp,
+    Answer, BindAnswer, IceNegotiation, MediaNegotiation, Message, RTCIceCandidateInit,
+    RTCSessionDescription, Sdp,
 };
 use crate::stream::webrtc::signalling_server::WebRTCSessionManagementInterface;
 use crate::stream::webrtc::turn_server::DEFAULT_STUN_ENDPOINT;
 use crate::stream::webrtc::turn_server::DEFAULT_TURN_ENDPOINT;
 use crate::stream::webrtc::webrtcbin_interface::WebRTCBinInterface;
 
-#[derive(Debug, Clone)]
-pub struct WebRTCSink(Arc<Mutex<WebRTCSinkInner>>);
-
-impl std::ops::Deref for WebRTCSink {
-    type Target = Mutex<WebRTCSinkInner>;
-
-    fn deref(&self) -> &Self::Target {
-        self.0.as_ref()
-    }
+#[derive(Clone)]
+pub struct WebRTCSinkWeakProxy {
+    bind: BindAnswer,
+    sender: WeakUnboundedSender<Result<Message>>,
 }
 
 #[derive(Debug)]
-pub struct WebRTCSinkInner {
+pub struct WebRTCSink {
     pub queue: gst::Element,
     pub webrtcbin: gst::Element,
     pub webrtcbin_sink_pad: gst::Pad,
     pub tee_src_pad: Option<gst::Pad>,
     pub bind: BindAnswer,
     /// MPSC channel's sender to send messages to the respective Websocket from Signaller server. Err can be used to end the WebSocket.
-    pub sender: Mutex<mpsc::UnboundedSender<Result<Message>>>,
+    pub sender: mpsc::UnboundedSender<Result<Message>>,
     pub end_reason: Option<String>,
 }
 impl SinkInterface for WebRTCSink {
@@ -47,10 +40,8 @@ impl SinkInterface for WebRTCSink {
         pipeline_id: &uuid::Uuid,
         tee_src_pad: gst::Pad,
     ) -> Result<()> {
-        let mut inner = self.0.lock().unwrap();
-
         // Configure transceiver https://gstreamer.freedesktop.org/documentation/webrtclib/gstwebrtc-transceiver.html?gi-language=c
-        let webrtcbin_sink_pad = &inner.webrtcbin_sink_pad;
+        let webrtcbin_sink_pad = &self.webrtcbin_sink_pad;
         let transceiver =
             webrtcbin_sink_pad.property::<gst_webrtc::WebRTCRTPTransceiver>("transceiver");
         transceiver.set_property(
@@ -61,433 +52,6 @@ impl SinkInterface for WebRTCSink {
         transceiver.set_property("fec-type", gst_webrtc::WebRTCFECType::None);
 
         // Link
-        inner.link(pipeline, pipeline_id, tee_src_pad)?;
-
-        // TODO: Workaround for bug: https://gitlab.freedesktop.org/gstreamer/gst-plugins-bad/-/issues/1539
-        // Reasoning: because we are not receiving the Disconnected | Failed | Closed of WebRTCPeerConnectionState,
-        // we are directly connecting to webrtcbin->transceiver->transport->connect_state_notify:
-        // When the bug is solved, we should remove this code and use WebRTCPeerConnectionState instead.
-        let weak_this = self.clone();
-        let rtp_sender = transceiver
-            .sender()
-            .context("Failed getting transceiver's RTP sender element")?;
-        rtp_sender.connect_notify(Some("transport"), move |rtp_sender, _pspec| {
-            let transport = rtp_sender.property::<gst_webrtc::WebRTCDTLSTransport>("transport");
-
-            debug!("DTLS Transport: {transport:#?}");
-
-            let weak_this = weak_this.clone();
-            transport.connect_state_notify(move |transport| {
-                use gst_webrtc::WebRTCDTLSTransportState::*;
-
-                let state = transport.state();
-                debug!("DTLS Transport Connection changed to {state:#?}");
-                match state {
-                    Failed | Closed => {
-                        if weak_this.lock().unwrap().webrtcbin.current_state()
-                            == gst::State::Playing
-                        {
-                            let weak_this = weak_this.clone();
-                            // Closing the channel from the same thread can cause a deadlock, so we are calling it from another one:
-                            std::thread::spawn(move || {
-                                weak_this.close("DTLS Transport connection lost")
-                            });
-                        }
-                    }
-                    _ => (),
-                }
-            });
-        });
-
-        Ok(())
-    }
-
-    #[instrument(level = "debug", skip(self))]
-    fn unlink(&self, pipeline: &gst::Pipeline, pipeline_id: &uuid::Uuid) -> Result<()> {
-        let inner = self.0.lock().unwrap(); // We are getting locked here!
-        inner.unlink(pipeline, pipeline_id)
-    }
-
-    #[instrument(level = "trace", skip(self))]
-    fn get_id(&self) -> uuid::Uuid {
-        self.0.lock().unwrap().get_id()
-    }
-
-    #[instrument(level = "debug", skip(self))]
-    fn get_sdp(&self) -> Result<gst_sdp::SDPMessage> {
-        self.0.lock().unwrap().get_sdp()
-    }
-
-    #[instrument(level = "debug", skip(self))]
-    fn start(&self) -> Result<()> {
-        self.0.lock().unwrap().start()
-    }
-
-    #[instrument(level = "debug", skip(self))]
-    fn eos(&self) {
-        self.0.lock().unwrap().eos()
-    }
-}
-
-impl WebRTCSink {
-    #[instrument(level = "debug")]
-    pub fn try_new(
-        bind: BindAnswer,
-        sender: mpsc::UnboundedSender<Result<Message>>,
-    ) -> Result<Self> {
-        let queue = gst::ElementFactory::make("queue")
-            .property_from_str("leaky", "downstream") // Throw away any data
-            .property("flush-on-eos", true)
-            .property("max-size-buffers", 0u32) // Disable buffers
-            .build()?;
-
-        let webrtcbin = gst::ElementFactory::make("webrtcbin")
-            .property_from_str("name", format!("webrtcbin-{}", bind.session_id).as_str())
-            .property("async-handling", true)
-            .property("bundle-policy", gst_webrtc::WebRTCBundlePolicy::MaxBundle) // https://webrtcstandards.info/sdp-bundle/
-            .property("latency", 0u32)
-            .property_from_str("stun-server", DEFAULT_STUN_ENDPOINT)
-            .property_from_str("turn-server", DEFAULT_TURN_ENDPOINT)
-            .build()?;
-
-        let webrtcbin_sink_pad = webrtcbin
-            .request_pad_simple("sink_%u")
-            .context("Failed requesting sink pad for webrtcsink")?;
-
-        sender.send(Ok(Message::from(Answer::StartSession(bind.clone()))))?;
-
-        let this = WebRTCSink(Arc::new(Mutex::new(WebRTCSinkInner {
-            queue,
-            webrtcbin,
-            webrtcbin_sink_pad,
-            tee_src_pad: None,
-            bind,
-            sender: Mutex::new(sender),
-            end_reason: None,
-        })));
-
-        let mut this_guard_result = this.lock();
-        let this_guard = this_guard_result.as_deref_mut().unwrap();
-        let webrtcbin = &this_guard.webrtcbin;
-
-        // Connect to on-negotiation-needed to handle sending an Offer
-        let weak_this = this.clone();
-        webrtcbin.connect("on-negotiation-needed", false, move |values| {
-            let element = values[0].get::<gst::Element>().expect("Invalid argument");
-
-            if let Err(error) = weak_this.on_negotiation_needed(&element) {
-                error!("Failed to negotiate: {error:?}");
-            }
-
-            None
-        });
-
-        // Whenever there is a new ICE candidate, send it to the peer
-        let weak_this = this.clone();
-        webrtcbin.connect("on-ice-candidate", false, move |values| {
-            let element = values[0].get::<gst::Element>().expect("Invalid argument");
-            let sdp_m_line_index = values[1].get::<u32>().expect("Invalid argument");
-            let candidate = values[2].get::<String>().expect("Invalid argument");
-
-            if let Err(error) = weak_this.on_ice_candidate(&element, &sdp_m_line_index, &candidate)
-            {
-                debug!("Failed to send ICE candidate: {error:#?}");
-            }
-            None
-        });
-
-        let weak_this = this.clone();
-        webrtcbin.connect_notify(Some("connection-state"), move |webrtcbin, _pspec| {
-            let state =
-                webrtcbin.property::<gst_webrtc::WebRTCPeerConnectionState>("connection-state");
-
-            weak_this.on_connection_state_change(webrtcbin, &state);
-        });
-
-        let weak_this = this.clone();
-        webrtcbin.connect_notify(Some("ice-connection-state"), move |webrtcbin, _pspec| {
-            let state =
-                webrtcbin.property::<gst_webrtc::WebRTCICEConnectionState>("ice-connection-state");
-
-            weak_this.on_ice_connection_state_change(webrtcbin, &state);
-        });
-
-        let weak_this = this.clone();
-        webrtcbin.connect_notify(Some("ice-gathering-state"), move |webrtcbin, _pspec| {
-            let state =
-                webrtcbin.property::<gst_webrtc::WebRTCICEGatheringState>("ice-gathering-state");
-
-            weak_this.on_ice_gathering_state_change(webrtcbin, &state);
-        });
-
-        drop(this_guard_result);
-        Ok(this)
-    }
-
-    #[instrument(level = "trace", skip(self))]
-    pub fn send(&self, message: Message) -> Result<()> {
-        self.lock()
-            .unwrap()
-            .sender
-            .lock()
-            .unwrap()
-            .send(Ok(message))
-            .context("Failed sending message {message:#?}")
-    }
-
-    #[instrument(level = "debug", skip(self))]
-    pub fn close(&self, reason: &str) {
-        let bind = &self.lock().unwrap().bind.clone();
-        if let Err(error) = Manager::remove_session(bind, reason.to_string()) {
-            error!("Failed removing session {bind:#?}: {error}");
-        }
-    }
-}
-
-impl WebRTCBinInterface for WebRTCSink {
-    // Whenever webrtcbin tells us that (re-)negotiation is needed, simply ask
-    // for a new offer SDP from webrtcbin without any customization and then
-    // asynchronously send it to the peer via the WebSocket connection
-    // #[instrument(level = "debug", skip(self))]
-    fn on_negotiation_needed(&self, webrtcbin: &gst::Element) -> Result<()> {
-        let this = self.clone();
-        let webrtcbin_clone = webrtcbin.clone();
-        let promise = gst::Promise::with_change_func(move |reply| {
-            let reply = match reply {
-                Ok(Some(reply)) => reply,
-                Ok(None) => {
-                    error!("Offer creation future got no response");
-                    return;
-                }
-                Err(error) => {
-                    error!("Failed to send SDP offer: {error:?}");
-                    return;
-                }
-            };
-
-            let offer = match reply.get_optional::<gst_webrtc::WebRTCSessionDescription>("offer") {
-                Ok(Some(offer)) => offer,
-                Ok(None) => {
-                    error!("Response got no \"offer\"");
-                    return;
-                }
-                Err(error) => {
-                    error!("Failed to send SDP offer: {error:?}");
-                    return;
-                }
-            };
-
-            if let Err(error) = this.on_offer_created(&webrtcbin_clone, &offer) {
-                error!("Failed to send SDP offer: {error:?}");
-            }
-        });
-
-        webrtcbin.emit_by_name::<()>("create-offer", &[&None::<gst::Structure>, &promise]);
-
-        Ok(())
-    }
-
-    // Once webrtcbin has create the offer SDP for us, handle it by sending it to the peer via the
-    // WebSocket connection
-    #[instrument(level = "debug", skip(self))]
-    fn on_offer_created(
-        &self,
-        _webrtcbin: &gst::Element,
-        offer: &gst_webrtc::WebRTCSessionDescription,
-    ) -> Result<()> {
-        // Recreate the SDP offer with our customized SDP
-        let offer =
-            gst_webrtc::WebRTCSessionDescription::new(offer.type_(), customize_sdp(&offer.sdp())?);
-
-        let Ok(sdp) = offer.sdp().as_text() else {
-            return Err(anyhow!("Failed reading the received SDP"));
-        };
-
-        // All good, then set local description
-        self.lock()
-            .unwrap()
-            .webrtcbin
-            .emit_by_name::<()>("set-local-description", &[&offer, &None::<gst::Promise>]);
-
-        debug!("Sending SDP offer to peer. Offer:\n{sdp}");
-
-        let message = MediaNegotiation {
-            bind: self.lock().unwrap().bind.clone(),
-            sdp: RTCSessionDescription::Offer(Sdp { sdp }),
-        }
-        .into();
-
-        self.send(message).context("Failed to send SDP offer")?;
-
-        Ok(())
-    }
-
-    // Once webrtcbin has create the answer SDP for us, handle it by sending it to the peer via the
-    // WebSocket connection
-    #[instrument(level = "debug", skip(self))]
-    fn on_answer_created(
-        &self,
-        _webrtcbin: &gst::Element,
-        answer: &gst_webrtc::WebRTCSessionDescription,
-    ) -> Result<()> {
-        // Recreate the SDP answer with our customized SDP
-        let answer = gst_webrtc::WebRTCSessionDescription::new(
-            answer.type_(),
-            customize_sdp(&answer.sdp())?,
-        );
-
-        let Ok(sdp) = answer.sdp().as_text() else {
-            return Err(anyhow!("Failed reading the received SDP"));
-        };
-
-        debug!("Sending SDP answer to peer. Answer:\n{sdp}");
-
-        // All good, then set local description
-        let message = MediaNegotiation {
-            bind: self.lock().unwrap().bind.clone(),
-            sdp: RTCSessionDescription::Answer(Sdp { sdp }),
-        }
-        .into();
-
-        self.send(message).context("Failed to send SDP answer")?;
-
-        Ok(())
-    }
-
-    #[instrument(level = "debug", skip(self))]
-    fn on_ice_candidate(
-        &self,
-        _webrtcbin: &gst::Element,
-        sdp_m_line_index: &u32,
-        candidate: &str,
-    ) -> Result<()> {
-        let message = IceNegotiation {
-            bind: self.lock().unwrap().bind.clone(),
-            ice: RTCIceCandidateInit {
-                candidate: Some(candidate.to_owned()),
-                sdp_mid: None,
-                sdp_m_line_index: Some(sdp_m_line_index.to_owned()),
-                username_fragment: None,
-            },
-        }
-        .into();
-
-        self.send(message).context("Failed to send ICE candidate")?;
-
-        debug!("ICE candidate created!");
-
-        Ok(())
-    }
-
-    #[instrument(level = "debug", skip(self))]
-    fn on_ice_gathering_state_change(
-        &self,
-        _webrtcbin: &gst::Element,
-        state: &gst_webrtc::WebRTCICEGatheringState,
-    ) {
-        if let gst_webrtc::WebRTCICEGatheringState::Complete = state {
-            debug!("ICE gathering complete")
-        }
-    }
-
-    #[instrument(level = "debug", skip(self))]
-    fn on_ice_connection_state_change(
-        &self,
-        _webrtcbin: &gst::Element,
-        state: &gst_webrtc::WebRTCICEConnectionState,
-    ) {
-        use gst_webrtc::WebRTCICEConnectionState::*;
-
-        debug!("ICE connection changed to {state:#?}");
-        match state {
-            Failed | Closed | Disconnected => self.close("ICE closed"),
-            _ => (),
-        };
-    }
-
-    #[instrument(level = "debug", skip(self))]
-    fn on_connection_state_change(
-        &self,
-        webrtcbin: &gst::Element,
-        state: &gst_webrtc::WebRTCPeerConnectionState,
-    ) {
-        use gst_webrtc::WebRTCPeerConnectionState::*;
-
-        debug!("Connection changed to {state:#?}");
-        match state {
-            // TODO: This would be the desired workflow, but it is not being detected, so we are using a workaround connecting direcly to the DTLS Transport connection state in the Session constructor.
-            Disconnected | Failed | Closed => {
-                warn!("For mantainers: Peer connection lost was detected by WebRTCPeerConnectionState, we should remove the workaround. State: {state:#?}");
-                // self.close("Connection lost"); // TODO: Keep this line commented until the forementioned bug is solved.
-            }
-            _ => (),
-        }
-    }
-
-    #[instrument(level = "debug", skip(self))]
-    fn handle_sdp(&self, sdp: &gst_webrtc::WebRTCSessionDescription) -> Result<()> {
-        self.lock()
-            .unwrap()
-            .webrtcbin
-            .emit_by_name::<()>("set-remote-description", &[&sdp, &None::<gst::Promise>]);
-        Ok(())
-    }
-
-    #[instrument(level = "debug", skip(self))]
-    fn handle_ice(&self, sdp_m_line_index: &u32, candidate: &str) -> Result<()> {
-        self.lock()
-            .unwrap()
-            .webrtcbin
-            .emit_by_name::<()>("add-ice-candidate", &[&sdp_m_line_index, &candidate]);
-        Ok(())
-    }
-}
-
-/// Because GSTreamer's WebRTCBin often crashes when receiving an invalid SDP,
-/// we use Mozzila's SDP parser to manipulate the SDP Message before giving it to GStreamer
-fn customize_sdp(sdp: &gst_sdp::SDPMessage) -> Result<gst_sdp::SDPMessage> {
-    let mut sdp = webrtc_sdp::parse_sdp(sdp.as_text()?.as_str(), false)?;
-
-    for media in sdp.media.iter_mut() {
-        let attributes = media.get_attributes().to_vec(); // This clone is necessary to avoid imutable borrow after a mutable borrow
-        for attribute in attributes {
-            use webrtc_sdp::attribute_type::SdpAttribute::*;
-
-            match attribute {
-                // Filter out unsupported/unwanted attributes
-                Recvonly | Sendrecv | Inactive => {
-                    media.remove_attribute((&attribute).into());
-                    debug!("Removed unsupported/unwanted attribute: {attribute:?}");
-                }
-                // Customize FMTP
-                // Here we are lying to the peer about our profile-level-id (to constrained-baseline) so any browser can accept it
-                Fmtp(mut fmtp) => {
-                    const CONSTRAINED_BASELINE_LEVEL_ID: u32 = 0x42e01f;
-                    fmtp.parameters.profile_level_id = CONSTRAINED_BASELINE_LEVEL_ID;
-                    fmtp.parameters.level_asymmetry_allowed = true;
-
-                    let attribute = webrtc_sdp::attribute_type::SdpAttribute::Fmtp(fmtp);
-
-                    debug!("FMTP attribute customized: {attribute:?}");
-
-                    media.set_attribute(attribute)?;
-                }
-                _ => continue,
-            }
-        }
-    }
-
-    gst_sdp::SDPMessage::parse_buffer(sdp.to_string().as_bytes()).map_err(anyhow::Error::msg)
-}
-
-impl SinkInterface for WebRTCSinkInner {
-    #[instrument(level = "debug", skip(self))]
-    fn link(
-        &mut self,
-        pipeline: &gst::Pipeline,
-        pipeline_id: &uuid::Uuid,
-        tee_src_pad: gst::Pad,
-    ) -> Result<()> {
         let sink_id = &self.get_id();
 
         // Set Tee's src pad
@@ -607,6 +171,55 @@ impl SinkInterface for WebRTCSinkInner {
         // Unblock data to go through this added Tee src pad
         tee_src_pad.remove_probe(tee_src_pad_data_blocker);
 
+        // TODO: Workaround for bug: https://gitlab.freedesktop.org/gstreamer/gst-plugins-bad/-/issues/1539
+        // Reasoning: because we are not receiving the Disconnected | Failed | Closed of WebRTCPeerConnectionState,
+        // we are directly connecting to webrtcbin->transceiver->transport->connect_state_notify:
+        // When the bug is solved, we should remove this code and use WebRTCPeerConnectionState instead.
+        let webrtcbin_clone = self.webrtcbin.downgrade();
+        let bind_clone = self.bind.clone();
+        let rtp_sender = transceiver
+            .sender()
+            .context("Failed getting transceiver's RTP sender element")?;
+        rtp_sender.connect_notify(Some("transport"), move |rtp_sender, _pspec| {
+            let transport = rtp_sender.property::<gst_webrtc::WebRTCDTLSTransport>("transport");
+
+            debug!("DTLS Transport: {transport:#?}");
+
+            let bind = bind_clone.clone();
+            let webrtcbin_clone = webrtcbin_clone.clone();
+            transport.connect_state_notify(move |transport| {
+                use gst_webrtc::WebRTCDTLSTransportState::*;
+
+                let bind = bind.clone();
+                let state = transport.state();
+                debug!("DTLS Transport Connection changed to {state:#?}");
+                match state {
+                    Failed | Closed => {
+                        if let Some(webrtcbin) = webrtcbin_clone.upgrade() {
+                            if webrtcbin.current_state() == gst::State::Playing {
+                                // Closing the channel from the same thread can cause a deadlock, so we are calling it from another one:
+                                std::thread::Builder::new()
+                                    .name("DTLSKiller".to_string())
+                                    .spawn(move || {
+                                        let bind = &bind.clone();
+                                        if let Err(error) = Manager::remove_session(
+                                            bind,
+                                            format!(
+                                                "DTLS Transport connection closed with: {state:?}"
+                                            ),
+                                        ) {
+                                            error!("Failed removing session {bind:#?}: {error}");
+                                        }
+                                    })
+                                    .expect("Failed spawing DTLSKiller thread");
+                            }
+                        }
+                    }
+                    _ => (),
+                }
+            });
+        });
+
         Ok(())
     }
 
@@ -688,22 +301,412 @@ impl SinkInterface for WebRTCSinkInner {
     }
 }
 
-impl Drop for WebRTCSinkInner {
-    #[instrument(level = "debug", skip(self))]
-    fn drop(&mut self) {
-        // Send EndSession to consumers, if the WebSocket and MPSC are still available
-        if let Ok(sender) = self.sender.lock() {
-            let question = Question::EndSession(EndSessionQuestion {
-                bind: self.bind.clone(),
-                reason: self
-                    .end_reason
-                    .clone()
-                    .unwrap_or_else(|| "unknown".to_string()),
+impl WebRTCSink {
+    #[instrument(level = "debug")]
+    pub fn try_new(
+        bind: BindAnswer,
+        sender: mpsc::UnboundedSender<Result<Message>>,
+    ) -> Result<Self> {
+        let queue = gst::ElementFactory::make("queue")
+            .property_from_str("leaky", "downstream") // Throw away any data
+            .property("flush-on-eos", true)
+            .property("max-size-buffers", 0u32) // Disable buffers
+            .build()?;
+
+        // Workaround to have a better name for the threads created by the WebRTCBin element
+        let webrtcbin = {
+            let (tx, rx) = std::sync::mpsc::sync_channel(1);
+            std::thread::Builder::new()
+                .name("WebRTCBin".to_string())
+                .spawn(move || {
+                    let webrtcbin = gst::ElementFactory::make("webrtcbin")
+                        .property_from_str(
+                            "name",
+                            format!("webrtcbin-{}", bind.session_id).as_str(),
+                        )
+                        .property("async-handling", true)
+                        .property("bundle-policy", gst_webrtc::WebRTCBundlePolicy::MaxBundle) // https://webrtcstandards.info/sdp-bundle/
+                        .property("latency", 0u32)
+                        .property_from_str("stun-server", DEFAULT_STUN_ENDPOINT)
+                        .property_from_str("turn-server", DEFAULT_TURN_ENDPOINT)
+                        .build();
+
+                    tx.send(webrtcbin).unwrap();
+                })
+                .expect("Failed spawning leak_inside_webrtcbin thread");
+            rx.recv()??
+        };
+
+        let webrtcbin_sink_pad = webrtcbin
+            .request_pad_simple("sink_%u")
+            .context("Failed requesting sink pad for webrtcsink")?;
+
+        sender.send(Ok(Message::from(Answer::StartSession(bind.clone()))))?;
+
+        let this = WebRTCSink {
+            queue,
+            webrtcbin,
+            webrtcbin_sink_pad,
+            tee_src_pad: None,
+            bind,
+            sender,
+            end_reason: None,
+        };
+
+        // Connect to on-negotiation-needed to handle sending an Offer
+        let weak_proxy = this.downgrade();
+        this.webrtcbin
+            .connect("on-negotiation-needed", false, move |values| {
+                let element = values[0].get::<gst::Element>().expect("Invalid argument");
+
+                if let Err(error) = weak_proxy.on_negotiation_needed(&element) {
+                    error!("Failed to negotiate: {error:?}");
+                }
+
+                None
             });
 
-            if let Err(send_err) = sender.send(Ok(Message::from(question))) {
-                error!("Failed to send EndSession question to MPSC channel: {send_err:?}");
+        // Whenever there is a new ICE candidate, send it to the peer
+        let weak_proxy = this.downgrade();
+        this.webrtcbin
+            .connect("on-ice-candidate", false, move |values| {
+                let element = values[0].get::<gst::Element>().expect("Invalid argument");
+                let sdp_m_line_index = values[1].get::<u32>().expect("Invalid argument");
+                let candidate = values[2].get::<String>().expect("Invalid argument");
+
+                if let Err(error) =
+                    weak_proxy.on_ice_candidate(&element, &sdp_m_line_index, &candidate)
+                {
+                    debug!("Failed to send ICE candidate: {error:#?}");
+                }
+
+                None
+            });
+
+        let weak_proxy = this.downgrade();
+        this.webrtcbin
+            .connect_notify(Some("connection-state"), move |webrtcbin, _pspec| {
+                let state =
+                    webrtcbin.property::<gst_webrtc::WebRTCPeerConnectionState>("connection-state");
+
+                if let Err(error) = weak_proxy.on_connection_state_change(webrtcbin, &state) {
+                    error!("Failed to processing connection-state: {error:?}");
+                }
+            });
+
+        let weak_proxy = this.downgrade();
+        this.webrtcbin
+            .connect_notify(Some("ice-connection-state"), move |webrtcbin, _pspec| {
+                let state = webrtcbin
+                    .property::<gst_webrtc::WebRTCICEConnectionState>("ice-connection-state");
+
+                if let Err(error) = weak_proxy.on_ice_connection_state_change(webrtcbin, &state) {
+                    error!("Failed to processing ice-connection-state: {error:?}");
+                }
+            });
+
+        let weak_proxy = this.downgrade();
+        this.webrtcbin
+            .connect_notify(Some("ice-gathering-state"), move |webrtcbin, _pspec| {
+                let state = webrtcbin
+                    .property::<gst_webrtc::WebRTCICEGatheringState>("ice-gathering-state");
+
+                if let Err(error) = weak_proxy.on_ice_gathering_state_change(webrtcbin, &state) {
+                    error!("Failed to processing ice-gathering-state: {error:?}");
+                }
+            });
+
+        Ok(this)
+    }
+
+    #[instrument(level = "debug", skip(self))]
+    fn downgrade(&self) -> WebRTCSinkWeakProxy {
+        WebRTCSinkWeakProxy {
+            bind: self.bind.clone(),
+            sender: self.sender.downgrade(),
+        }
+    }
+
+    #[instrument(level = "debug", skip(self))]
+    pub fn handle_sdp(&self, sdp: &gst_webrtc::WebRTCSessionDescription) -> Result<()> {
+        self.downgrade().handle_sdp(&self.webrtcbin, sdp)
+    }
+
+    #[instrument(level = "debug", skip(self))]
+    pub fn handle_ice(&self, sdp_m_line_index: &u32, candidate: &str) -> Result<()> {
+        self.downgrade()
+            .handle_ice(&self.webrtcbin, sdp_m_line_index, candidate)
+    }
+}
+
+impl WebRTCBinInterface for WebRTCSinkWeakProxy {
+    // Whenever webrtcbin tells us that (re-)negotiation is needed, simply ask
+    // for a new offer SDP from webrtcbin without any customization and then
+    // asynchronously send it to the peer via the WebSocket connection
+    #[instrument(level = "debug", skip(self))]
+    fn on_negotiation_needed(&self, webrtcbin: &gst::Element) -> Result<()> {
+        let this = self.clone();
+        let webrtcbin_weak = webrtcbin.downgrade();
+        let promise = gst::Promise::with_change_func(move |reply| {
+            let reply = match reply {
+                Ok(Some(reply)) => reply,
+                Ok(None) => {
+                    error!("Offer creation future got no response");
+                    return;
+                }
+                Err(error) => {
+                    error!("Failed to send SDP offer: {error:?}");
+                    return;
+                }
+            };
+
+            let offer = match reply.get_optional::<gst_webrtc::WebRTCSessionDescription>("offer") {
+                Ok(Some(offer)) => offer,
+                Ok(None) => {
+                    error!("Response got no \"offer\"");
+                    return;
+                }
+                Err(error) => {
+                    error!("Failed to send SDP offer: {error:?}");
+                    return;
+                }
+            };
+
+            if let Some(webrtcbin) = webrtcbin_weak.upgrade() {
+                if let Err(error) = this.on_offer_created(&webrtcbin, &offer) {
+                    error!("Failed to send SDP offer: {error:?}");
+                }
+            }
+        });
+
+        webrtcbin.emit_by_name::<()>("create-offer", &[&None::<gst::Structure>, &promise]);
+
+        Ok(())
+    }
+
+    // Once webrtcbin has create the offer SDP for us, handle it by sending it to the peer via the
+    // WebSocket connection
+    #[instrument(level = "debug", skip(self))]
+    fn on_offer_created(
+        &self,
+        webrtcbin: &gst::Element,
+        offer: &gst_webrtc::WebRTCSessionDescription,
+    ) -> Result<()> {
+        // Recreate the SDP offer with our customized SDP
+        let offer =
+            gst_webrtc::WebRTCSessionDescription::new(offer.type_(), customize_sdp(&offer.sdp())?);
+
+        let Ok(sdp) = offer.sdp().as_text() else {
+            return Err(anyhow!("Failed reading the received SDP"));
+        };
+
+        // All good, then set local description
+        webrtcbin.emit_by_name::<()>("set-local-description", &[&offer, &None::<gst::Promise>]);
+
+        debug!("Sending SDP offer to peer. Offer:\n{sdp}");
+
+        let message = MediaNegotiation {
+            bind: self.bind.clone(),
+            sdp: RTCSessionDescription::Offer(Sdp { sdp }),
+        }
+        .into();
+
+        self.sender
+            .upgrade()
+            .context("Failed accessing MPSC Sender")?
+            .send(Ok(message))
+            .context("Failed to send SDP offer")?;
+
+        Ok(())
+    }
+
+    // Once webrtcbin has create the answer SDP for us, handle it by sending it to the peer via the
+    // WebSocket connection
+    #[instrument(level = "debug", skip(self))]
+    fn on_answer_created(
+        &self,
+        _webrtcbin: &gst::Element,
+        answer: &gst_webrtc::WebRTCSessionDescription,
+    ) -> Result<()> {
+        // Recreate the SDP answer with our customized SDP
+        let answer = gst_webrtc::WebRTCSessionDescription::new(
+            answer.type_(),
+            customize_sdp(&answer.sdp())?,
+        );
+
+        let Ok(sdp) = answer.sdp().as_text() else {
+            return Err(anyhow!("Failed reading the received SDP"));
+        };
+
+        debug!("Sending SDP answer to peer. Answer:\n{sdp}");
+
+        // All good, then set local description
+        let message = MediaNegotiation {
+            bind: self.bind.clone(),
+            sdp: RTCSessionDescription::Answer(Sdp { sdp }),
+        }
+        .into();
+
+        self.sender
+            .upgrade()
+            .context("Failed accessing MPSC Sender")?
+            .send(Ok(message))
+            .context("Failed to send SDP answer")?;
+
+        Ok(())
+    }
+
+    #[instrument(level = "debug", skip(self))]
+    fn on_ice_candidate(
+        &self,
+        _webrtcbin: &gst::Element,
+        sdp_m_line_index: &u32,
+        candidate: &str,
+    ) -> Result<()> {
+        let message = IceNegotiation {
+            bind: self.bind.clone(),
+            ice: RTCIceCandidateInit {
+                candidate: Some(candidate.to_owned()),
+                sdp_mid: None,
+                sdp_m_line_index: Some(sdp_m_line_index.to_owned()),
+                username_fragment: None,
+            },
+        }
+        .into();
+
+        self.sender
+            .upgrade()
+            .context("Failed accessing MPSC Sender")?
+            .send(Ok(message))
+            .context("Failed to send ICE candidate")?;
+
+        debug!("ICE candidate created!");
+
+        Ok(())
+    }
+
+    #[instrument(level = "debug", skip(self))]
+    fn on_ice_gathering_state_change(
+        &self,
+        _webrtcbin: &gst::Element,
+        state: &gst_webrtc::WebRTCICEGatheringState,
+    ) -> Result<()> {
+        if let gst_webrtc::WebRTCICEGatheringState::Complete = state {
+            debug!("ICE gathering complete")
+        }
+
+        Ok(())
+    }
+
+    #[instrument(level = "debug", skip(self))]
+    fn on_ice_connection_state_change(
+        &self,
+        webrtcbin: &gst::Element,
+        state: &gst_webrtc::WebRTCICEConnectionState,
+    ) -> Result<()> {
+        use gst_webrtc::WebRTCICEConnectionState::*;
+
+        debug!("ICE connection changed to {state:#?}");
+        match state {
+            Completed => {
+                let srcpads = webrtcbin.src_pads();
+                if let Some(srcpad) = srcpads.first() {
+                    srcpad.send_event(
+                        gst_video::UpstreamForceKeyUnitEvent::builder()
+                            .all_headers(true)
+                            .build(),
+                    );
+                }
+            }
+            Failed | Closed | Disconnected => {
+                if let Err(error) =
+                    Manager::remove_session(&self.bind, format!("ICE closed with: {state:?}"))
+                {
+                    error!("Failed removing session {:#?}: {error}", self.bind);
+                }
+            }
+            _ => (),
+        };
+
+        Ok(())
+    }
+
+    #[instrument(level = "debug", skip(self))]
+    fn on_connection_state_change(
+        &self,
+        _webrtcbin: &gst::Element,
+        state: &gst_webrtc::WebRTCPeerConnectionState,
+    ) -> Result<()> {
+        use gst_webrtc::WebRTCPeerConnectionState::*;
+
+        debug!("Connection changed to {state:#?}");
+        match state {
+            // TODO: This would be the desired workflow, but it is not being detected, so we are using a workaround connecting direcly to the DTLS Transport connection state in the Session constructor.
+            Disconnected | Failed | Closed => {
+                warn!("For mantainers: Peer connection lost was detected by WebRTCPeerConnectionState, we should remove the workaround. State: {state:#?}");
+                // self.close("Connection lost"); // TODO: Keep this line commented until the forementioned bug is solved.
+            }
+            _ => (),
+        }
+
+        Ok(())
+    }
+
+    #[instrument(level = "debug", skip(self))]
+    fn handle_sdp(
+        &self,
+        webrtcbin: &gst::Element,
+        sdp: &gst_webrtc::WebRTCSessionDescription,
+    ) -> Result<()> {
+        webrtcbin.emit_by_name::<()>("set-remote-description", &[&sdp, &None::<gst::Promise>]);
+        Ok(())
+    }
+
+    #[instrument(level = "debug", skip(self))]
+    fn handle_ice(
+        &self,
+        webrtcbin: &gst::Element,
+        sdp_m_line_index: &u32,
+        candidate: &str,
+    ) -> Result<()> {
+        webrtcbin.emit_by_name::<()>("add-ice-candidate", &[&sdp_m_line_index, &candidate]);
+        Ok(())
+    }
+}
+
+/// Because GSTreamer's WebRTCBin often crashes when receiving an invalid SDP,
+/// we use Mozzila's SDP parser to manipulate the SDP Message before giving it to GStreamer
+fn customize_sdp(sdp: &gst_sdp::SDPMessage) -> Result<gst_sdp::SDPMessage> {
+    let mut sdp = webrtc_sdp::parse_sdp(sdp.as_text()?.as_str(), false)?;
+
+    for media in sdp.media.iter_mut() {
+        let attributes = media.get_attributes().to_vec(); // This clone is necessary to avoid imutable borrow after a mutable borrow
+        for attribute in attributes {
+            use webrtc_sdp::attribute_type::SdpAttribute::*;
+
+            match attribute {
+                // Filter out unsupported/unwanted attributes
+                Recvonly | Sendrecv | Inactive => {
+                    media.remove_attribute((&attribute).into());
+                    debug!("Removed unsupported/unwanted attribute: {attribute:?}");
+                }
+                // Customize FMTP
+                // Here we are lying to the peer about our profile-level-id (to constrained-baseline) so any browser can accept it
+                Fmtp(mut fmtp) => {
+                    const CONSTRAINED_BASELINE_LEVEL_ID: u32 = 0x42e01f;
+                    fmtp.parameters.profile_level_id = CONSTRAINED_BASELINE_LEVEL_ID;
+                    fmtp.parameters.level_asymmetry_allowed = true;
+
+                    let attribute = webrtc_sdp::attribute_type::SdpAttribute::Fmtp(fmtp);
+
+                    debug!("FMTP attribute customized: {attribute:?}");
+
+                    media.set_attribute(attribute)?;
+                }
+                _ => continue,
             }
         }
     }
+
+    gst_sdp::SDPMessage::parse_buffer(sdp.to_string().as_bytes()).map_err(anyhow::Error::msg)
 }

--- a/src/stream/webrtc/webrtcbin_interface.rs
+++ b/src/stream/webrtc/webrtcbin_interface.rs
@@ -36,25 +36,34 @@ pub trait WebRTCBinInterface {
         &self,
         webrtcbin: &gst::Element,
         state: &gst_webrtc::WebRTCICEGatheringState,
-    );
+    ) -> Result<()>;
 
     /// Signal emitted when this WebRTCBin ICE connection state changes.
     fn on_ice_connection_state_change(
         &self,
         webrtcbin: &gst::Element,
         state: &gst_webrtc::WebRTCICEConnectionState,
-    );
+    ) -> Result<()>;
 
     /// Signal emitted when this WebRTCBin connection state changes.
     fn on_connection_state_change(
         &self,
         webrtcbin: &gst::Element,
         state: &gst_webrtc::WebRTCPeerConnectionState,
-    );
+    ) -> Result<()>;
 
     /// Callback called by the WebRTC Signalling server (directly or by means of a session manager) for it to handle the incoming SDP.
-    fn handle_sdp(&self, sdp: &gst_webrtc::WebRTCSessionDescription) -> Result<()>;
+    fn handle_sdp(
+        &self,
+        webrtcbin: &gst::Element,
+        sdp: &gst_webrtc::WebRTCSessionDescription,
+    ) -> Result<()>;
 
     /// Callback called by the WebRTC Signalling server (directly or by means of a session manager) for it to handle the incoming ICE candidate.
-    fn handle_ice(&self, sdp_m_line_index: &u32, candidate: &str) -> Result<()>;
+    fn handle_ice(
+        &self,
+        webrtcbin: &gst::Element,
+        sdp_m_line_index: &u32,
+        candidate: &str,
+    ) -> Result<()>;
 }


### PR DESCRIPTION
The thread leak was due to a reference to the webrtcbin element living inside the closures, keeping webrtcbin threads alive forever.