### PR TITLE
github: workflows: rust: Remove cargo publish

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -31,10 +31,3 @@ jobs:
     - name: Run tests
       run: |
         cargo test --verbose
-    - name: Cargo publish
-      if: startsWith(github.ref, 'refs/tags/')
-      env:
-        TOKEN: ${{ secrets.TOKEN }}
-      run: |
-        cargo package --no-verify
-        [[ "$(git describe --tags)" =~ ^[0-9]+.[0-9]+.[0-9]+$ ]] && cargo publish --allow-dirty --token $TOKEN || echo "No tag availale for this commit."


### PR DESCRIPTION
We depend of packages that are not published and the project is a binary