### PR TITLE
Fix panic when recreating streams

### DIFF
--- a/src/stream/mod.rs
+++ b/src/stream/mod.rs
@@ -161,17 +161,17 @@ impl Stream {
                 }
 
                 // Try to recreate the stream
-                *state.lock().unwrap() = match StreamState::try_new(
-                    &video_and_stream_information,
-                    &pipeline_id,
-                ) {
-                    Ok(state) => state,
-                    Err(error) => {
-                        error!("Failed to recreate the stream {pipeline_id:?}: {error:#?}. Trying again in one second...");
-                        std::thread::sleep(std::time::Duration::from_secs(1));
-                        continue;
-                    }
-                };
+                if let Ok(mut state) = state.lock() {
+                    *state = match StreamState::try_new(&video_and_stream_information, &pipeline_id)
+                    {
+                        Ok(state) => state,
+                        Err(error) => {
+                            error!("Failed to recreate the stream {pipeline_id:?}: {error:#?}. Trying again in one second...");
+                            std::thread::sleep(std::time::Duration::from_secs(1));
+                            continue;
+                        }
+                    };
+                }
             }
 
             if *terminated.lock().unwrap() {

--- a/src/stream/pipeline/runner.rs
+++ b/src/stream/pipeline/runner.rs
@@ -77,10 +77,10 @@ impl PipelineRunner {
         // Check if we need to break external loop.
         // Some cameras have a duplicated timestamp when starting.
         // to avoid restarting the camera once and once again,
-        // this checks for a maximum of 10 lost before restarting.
+        // this checks for a maximum number of lost before restarting.
         let mut previous_position: Option<gst::ClockTime> = None;
         let mut lost_timestamps: usize = 0;
-        let max_lost_timestamps: usize = 15;
+        let max_lost_timestamps: usize = 30;
 
         'outer: loop {
             std::thread::sleep(std::time::Duration::from_millis(100));


### PR DESCRIPTION
The problem is that streams are recreated from inside the PipelineRunner context, which contrary to the main context, doesn't have a tokio runtime, thus, it panics when trying to spawn tokio tasks.

This is not the optimal solution 'cause every mavlink camera will end up creating a new tokio runtime, which is a waste of resources in this case, but still, this is a valid simple solution.