### PR TITLE
Add webrtc test via CI

### DIFF
--- a/.github/workflows/test_webrtc_leak.yml
+++ b/.github/workflows/test_webrtc_leak.yml
@@ -1,0 +1,35 @@
+name: Test webrtc thread leak
+
+on: [push, pull_request]
+
+jobs:
+  test-webrtc-thread-leak:
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: actions/checkout@v2
+
+    - name: Setup Chromedriver
+      uses: nanasess/setup-chromedriver@v2
+
+    - name: Install libraries
+      run: |
+        sudo apt install -y --no-install-recommends ca-certificates gnupg
+        sudo apt update
+        sudo apt install -y chromium-chromedriver
+        sudo apt install -y libunwind-dev
+        sudo apt install -y --no-install-recommends libclang-dev libssl-dev pkg-config libmount-dev libsepol-dev libselinux1-dev libglib2.0-dev libgudev-1.0-dev \
+          libgstreamer1.0-dev libgstreamer-plugins-base1.0-dev libgstreamer-plugins-good1.0-dev libgstreamer-plugins-bad1.0-dev libgstrtspserver-1.0-dev \
+          libgstreamer-plugins-base1.0-0 libgstreamer-plugins-good1.0-0 libgstreamer-plugins-bad1.0-0 \
+          gstreamer1.0-x gstreamer1.0-nice gstreamer1.0-tools gstreamer1.0-plugins-base gstreamer1.0-plugins-good \
+          gstreamer1.0-plugins-bad gstreamer1.0-plugins-ugly gstreamer1.0-libav
+        gst-inspect-1.0 # Update database
+        chromedriver --port=6666& # Start webdriver for test
+
+    - name: Run test
+      run: |
+        export DISPLAY=:99
+        chromedriver --url-base=/wd/hub &
+        cargo build
+        RUST_BACKTRACE=1 timeout 300 cargo run --verbose -- \
+          --mavlink udpin:0.0.0.0:6666 --verbose --default-settings WebRTCTest --enable-thread-counter --enable-webrtc-task-test 6666 || echo "Test failed" && exit 1

--- a/src/custom/mod.rs
+++ b/src/custom/mod.rs
@@ -4,18 +4,21 @@ use crate::cli;
 use crate::video_stream::types::VideoAndStreamInformation;
 
 mod bluerov;
+mod test;
 
 #[derive(ValueEnum, PartialEq, Debug, Clone)]
 #[clap(rename_all = "verbatim")]
 pub enum CustomEnvironment {
     BlueROVUDP,
     BlueROVRTSP,
+    WebRTCTest,
 }
 
 pub fn create_default_streams() -> Vec<VideoAndStreamInformation> {
     match cli::manager::default_settings() {
         Some(CustomEnvironment::BlueROVUDP) => bluerov::udp(),
         Some(CustomEnvironment::BlueROVRTSP) => bluerov::rtsp(),
+        Some(CustomEnvironment::WebRTCTest) => test::take_webrtc_stream(),
         _ => vec![],
     }
 }

--- a/src/custom/test.rs
+++ b/src/custom/test.rs
@@ -1,0 +1,29 @@
+use url::Url;
+
+use crate::stream::types::*;
+use crate::video::{self, types::*, video_source_gst::VideoSourceGstType};
+use crate::video_stream::types::VideoAndStreamInformation;
+
+pub fn take_webrtc_stream() -> Vec<VideoAndStreamInformation> {
+    let size = STANDARD_SIZES.last().unwrap();
+    vec![VideoAndStreamInformation {
+        name: format!("WebRTC fake stream for thread leak"),
+        stream_information: StreamInformation {
+            endpoints: vec![Url::parse("udp://0.0.0.0:8554/test").unwrap()],
+            configuration: CaptureConfiguration::Video(VideoCaptureConfiguration {
+                encode: VideoEncodeType::H264,
+                height: size.1,
+                width: size.0,
+                frame_interval: FrameInterval {
+                    denominator: 10,
+                    numerator: 1,
+                },
+            }),
+            extended_configuration: None,
+        },
+        video_source: VideoSourceType::Gst(video::video_source_gst::VideoSourceGst {
+            name: "Fake".into(),
+            source: VideoSourceGstType::Fake("ball".into()),
+        }),
+    }]
+}

--- a/src/helper/develop.rs
+++ b/src/helper/develop.rs
@@ -30,7 +30,7 @@ async fn task(mut counter: i32) -> Result<()> {
         for button in ["add-consumer", "add-session", "remove-all-consumers"] {
             driver
                 .query(By::Id(button))
-                .wait(Duration::from_secs(10), Duration::from_millis(100))
+                .wait(Duration::from_secs(60), Duration::from_millis(100))
                 .first()
                 .await?
                 .click()

--- a/src/helper/develop.rs
+++ b/src/helper/develop.rs
@@ -16,7 +16,10 @@ async fn task(mut counter: i32) -> Result<()> {
     let port = cli::manager::enable_webrtc_task_test().unwrap();
     let driver = WebDriver::new(&format!("http://localhost:{}", port), caps)
         .await
-        .expect("Failed to create web driver.");
+        .unwrap_or_else(|_| {
+            error!("Failed to connect with WebDriver.");
+            std::process::exit(-1)
+        });
 
     driver
         .goto("http://0.0.0.0:6020/webrtc/index.html")

--- a/src/helper/develop.rs
+++ b/src/helper/develop.rs
@@ -28,6 +28,7 @@ async fn task(mut counter: i32) -> Result<()> {
 
     loop {
         for button in ["add-consumer", "add-session", "remove-all-consumers"] {
+            info!("Looking for element: {button}");
             driver
                 .query(By::Id(button))
                 .wait(Duration::from_secs(60), Duration::from_millis(100))


### PR DESCRIPTION
The test runs fine locally with:
```
cargo run --verbose -- --mavlink udpin:0.0.0.0:6666 --verbose --enable-thread-counter --enable-webrtc-task-test --default-settings WebRTCTest --reset
```

No idea why is failing on CI, crashing in a wrong scenario. I believe that @joaoantoniocardoso async rework may fix the issue on CI for this patch. 