### PR TITLE
Fix stream recreation crashes and thread starvation caused by MAVLink-related thread leak

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -44,7 +44,7 @@ async fn main() -> Result<(), std::io::Error> {
 
     stream::webrtc::signalling_server::SignallingServer::default();
 
-    if let Err(error) = stream::manager::start_default() {
+    if let Err(error) = stream::manager::start_default().await {
         error!("Failed to start default streams. Reason: {error:?}")
     }
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -18,7 +18,7 @@ mod stream;
 mod video;
 mod video_stream;
 
-#[actix_web::main]
+#[tokio::main(flavor = "multi_thread", worker_threads = 10)]
 async fn main() -> Result<(), std::io::Error> {
     // CLI should be started before logger to allow control over verbosity
     cli::manager::init();
@@ -42,11 +42,13 @@ async fn main() -> Result<(), std::io::Error> {
         helper::develop::start_check_tasks_on_webrtc_reconnects();
     }
 
-    stream::webrtc::signalling_server::SignallingServer::default();
+    let _signalling_server = stream::webrtc::signalling_server::SignallingServer::default();
 
     if let Err(error) = stream::manager::start_default().await {
         error!("Failed to start default streams. Reason: {error:?}")
     }
 
-    server::manager::run(&cli::manager::server_address()).await
+    server::manager::run(&cli::manager::server_address()).await?;
+
+    Ok(())
 }

--- a/src/server/pages.rs
+++ b/src/server/pages.rs
@@ -232,7 +232,7 @@ pub fn v4l_post(json: web::Json<V4lControl>) -> HttpResponse {
 pub async fn reset_settings(query: web::Query<ResetSettings>) -> HttpResponse {
     if query.all.unwrap_or_default() {
         settings::manager::reset();
-        if let Err(error) = stream_manager::start_default() {
+        if let Err(error) = stream_manager::start_default().await {
             return HttpResponse::InternalServerError()
                 .content_type("text/plain")
                 .body(format!("{error:#?}"));
@@ -269,7 +269,7 @@ pub async fn streams() -> HttpResponse {
 
 #[api_v2_operation]
 /// Create a video stream
-pub fn streams_post(json: web::Json<PostStream>) -> HttpResponse {
+pub async fn streams_post(json: web::Json<PostStream>) -> HttpResponse {
     let json = json.into_inner();
 
     let video_source = match video_source::get_video_source(&json.source) {
@@ -285,7 +285,9 @@ pub fn streams_post(json: web::Json<PostStream>) -> HttpResponse {
         name: json.name,
         stream_information: json.stream_information,
         video_source,
-    }) {
+    })
+    .await
+    {
         return HttpResponse::NotAcceptable()
             .content_type("text/plain")
             .body(format!("{error:#?}"));

--- a/src/stream/manager.rs
+++ b/src/stream/manager.rs
@@ -571,6 +571,8 @@ impl StreamManagementInterface<StreamStatus> for Manager {
         }
         manager.update_settings();
 
+        info!("Stream {stream_id} successfully added!");
+
         Ok(())
     }
 

--- a/src/stream/mod.rs
+++ b/src/stream/mod.rs
@@ -109,6 +109,13 @@ impl Stream {
                 .pipeline_runner
                 .is_running()
             {
+                // First, finish the MAVLink tasks
+                {
+                    if let Some(mavlink) = state.write().unwrap().mavlink_camera.take() {
+                        drop(mavlink);
+                    }
+                }
+
                 // If it's a camera, try to update the device
                 if let VideoSourceType::Local(_) = video_and_stream_information.video_source {
                     let mut streams = vec![video_and_stream_information.clone()];

--- a/src/stream/mod.rs
+++ b/src/stream/mod.rs
@@ -298,12 +298,9 @@ impl Drop for StreamState {
         if let Err(error) = pipeline.set_state(::gst::State::Null) {
             error!("Failed setting Pipeline state to Null. Reason: {error:?}");
         }
-        if let Err(error) = wait_for_element_state(
-            pipeline.upcast_ref::<::gst::Element>(),
-            ::gst::State::Null,
-            100,
-            10,
-        ) {
+        if let Err(error) =
+            wait_for_element_state(pipeline.downgrade(), ::gst::State::Null, 100, 10)
+        {
             let _ = pipeline.set_state(::gst::State::Null);
             error!("Failed setting Pipeline state to Null. Reason: {error:?}");
         }

--- a/src/stream/mod.rs
+++ b/src/stream/mod.rs
@@ -8,7 +8,7 @@ pub mod webrtc;
 
 use std::sync::{Arc, Mutex};
 
-use crate::mavlink::mavlink_camera::MavlinkCameraHandle;
+use crate::mavlink::mavlink_camera::MavlinkCamera;
 use crate::video::types::{VideoEncodeType, VideoSourceType};
 use crate::video::video_source::cameras_available;
 use crate::video_stream::types::VideoAndStreamInformation;
@@ -42,7 +42,7 @@ pub struct StreamState {
     pub pipeline_id: PeerId,
     pub pipeline: Pipeline,
     pub video_and_stream_information: VideoAndStreamInformation,
-    pub mavlink_camera: Option<MavlinkCameraHandle>,
+    pub mavlink_camera: Option<MavlinkCamera>,
 }
 
 impl Stream {

--- a/src/stream/pipeline/mod.rs
+++ b/src/stream/pipeline/mod.rs
@@ -198,7 +198,7 @@ impl PipelineState {
         // added.
         if !matches!(&sink, Sink::Image(..)) {
             if let Err(error) = pipeline.sync_children_states() {
-                error!("Failed to syncronize children states. Reason: {:?}", error);
+                error!("Failed to syncronize children states. Reason: {error:?}");
             }
         }
 

--- a/src/stream/pipeline/mod.rs
+++ b/src/stream/pipeline/mod.rs
@@ -165,12 +165,9 @@ impl PipelineState {
             }
         }
 
-        if let Err(error) = wait_for_element_state(
-            pipeline.upcast_ref::<gst::Element>(),
-            gst::State::Playing,
-            100,
-            2,
-        ) {
+        if let Err(error) =
+            wait_for_element_state(pipeline.downgrade(), gst::State::Playing, 100, 2)
+        {
             let _ = pipeline.set_state(gst::State::Null);
             sink.unlink(pipeline, pipeline_id)?;
             return Err(anyhow!(

--- a/src/stream/pipeline/mod.rs
+++ b/src/stream/pipeline/mod.rs
@@ -213,15 +213,16 @@ impl PipelineState {
     #[instrument(level = "info", skip(self))]
     pub fn remove_sink(&mut self, sink_id: &uuid::Uuid) -> Result<()> {
         let pipeline_id = &self.pipeline_id;
-        let sink = self.sinks.remove(sink_id).context(format!(
-            "Failed to remove sink {sink_id} from Sinks of the Pipeline {pipeline_id}"
-        ))?;
 
         let pipeline = &self.pipeline;
         pipeline.debug_to_dot_file_with_ts(
             gst::DebugGraphDetails::all(),
             format!("pipeline-{pipeline_id}-sink-{sink_id}-before-removing"),
         );
+
+        let sink = self.sinks.remove(sink_id).context(format!(
+            "Failed to remove sink {sink_id} from Sinks of the Pipeline {pipeline_id}"
+        ))?;
 
         // Terminate the Sink
         sink.eos();

--- a/src/stream/sink/image_sink.rs
+++ b/src/stream/sink/image_sink.rs
@@ -196,11 +196,6 @@ impl SinkInterface for ImageSink {
             return Err(anyhow!(msg));
         }
 
-        // Syncronize SinkPipeline
-        if let Err(sync_err) = self.pipeline.sync_children_states() {
-            error!("Failed to syncronize children states: {sync_err:?}");
-        }
-
         // Unblock data to go through this added Tee src pad
         tee_src_pad.remove_probe(tee_src_pad_data_blocker);
 

--- a/src/stream/sink/rtsp_sink.rs
+++ b/src/stream/sink/rtsp_sink.rs
@@ -60,7 +60,7 @@ impl SinkInterface for RtspSink {
         // Add the Sink elements to the Pipeline
         let elements = &[&self.queue, &self.sink];
         if let Err(add_err) = pipeline.add_many(elements) {
-            let msg = format!("Failed to add WebRTCSink's elements to the Pipeline: {add_err:?}");
+            let msg = format!("Failed to add RTSP's elements to the Pipeline: {add_err:?}");
             error!(msg);
 
             if let Some(parent) = tee_src_pad.parent_element() {

--- a/src/stream/sink/udp_sink.rs
+++ b/src/stream/sink/udp_sink.rs
@@ -144,11 +144,6 @@ impl SinkInterface for UdpSink {
             return Err(anyhow!(msg));
         }
 
-        // Syncronize SinkPipeline
-        if let Err(sync_err) = self.pipeline.sync_children_states() {
-            error!("Failed to syncronize children states: {sync_err:?}");
-        }
-
         // Unblock data to go through this added Tee src pad
         tee_src_pad.remove_probe(tee_src_pad_data_blocker);
 

--- a/src/stream/sink/udp_sink.rs
+++ b/src/stream/sink/udp_sink.rs
@@ -82,7 +82,7 @@ impl SinkInterface for UdpSink {
             .expect("No sink pad found on ProxySink");
         if let Err(link_err) = queue_src_pad.link(proxysink_sink_pad) {
             let msg =
-                format!("Failed to link Queue's src pad with WebRTCBin's sink pad: {link_err:?}");
+                format!("Failed to link Queue's src pad with ProxySink's sink pad: {link_err:?}");
             error!(msg);
 
             if let Some(parent) = tee_src_pad.parent_element() {
@@ -337,15 +337,15 @@ impl UdpSink {
 
         // Add Sink elements to the Sink's Pipeline
         let elements = [&_proxysrc, &_udpsink];
-        if let Err(add_err) = pipeline.add_many(&elements) {
+        if let Err(add_err) = pipeline.add_many(elements) {
             return Err(anyhow!(
                 "Failed adding UdpSink's elements to Sink Pipeline: {add_err:?}"
             ));
         }
 
         // Link Sink's elements
-        if let Err(link_err) = gst::Element::link_many(&elements) {
-            if let Err(remove_err) = pipeline.remove_many(&elements) {
+        if let Err(link_err) = gst::Element::link_many(elements) {
+            if let Err(remove_err) = pipeline.remove_many(elements) {
                 warn!("Failed removing elements from UdpSink Pipeline: {remove_err:?}")
             };
             return Err(anyhow!("Failed linking UdpSink's elements: {link_err:?}"));

--- a/src/stream/sink/udp_sink.rs
+++ b/src/stream/sink/udp_sink.rs
@@ -264,9 +264,13 @@ impl SinkInterface for UdpSink {
 
     #[instrument(level = "debug", skip(self))]
     fn eos(&self) {
-        if let Err(error) = self.pipeline.post_message(gst::message::Eos::new()) {
-            error!("Failed posting Eos message into Sink bus. Reason: {error:?}");
-        }
+        let pipeline_weak = self.pipeline.downgrade();
+        std::thread::spawn(move || {
+            let pipeline = pipeline_weak.upgrade().unwrap();
+            if let Err(error) = pipeline.post_message(gst::message::Eos::new()) {
+                error!("Failed posting Eos message into Sink bus. Reason: {error:?}");
+            }
+        });
     }
 }
 

--- a/src/stream/sink/webrtc_sink.rs
+++ b/src/stream/sink/webrtc_sink.rs
@@ -293,9 +293,13 @@ impl SinkInterface for WebRTCSink {
 
     #[instrument(level = "debug", skip(self))]
     fn eos(&self) {
-        if let Err(error) = self.webrtcbin.post_message(gst::message::Eos::new()) {
-            error!("Failed posting Eos message into Sink bus. Reason: {error:?}");
-        }
+        let webrtcbin_weak = self.webrtcbin.downgrade();
+        std::thread::spawn(move || {
+            let webrtcbin = webrtcbin_weak.upgrade().unwrap();
+            if let Err(error) = webrtcbin.post_message(gst::message::Eos::new()) {
+                error!("Failed posting Eos message into Sink bus. Reason: {error:?}");
+            }
+        });
     }
 }
 


### PR DESCRIPTION
note: **Merge after #303**

This work:
- Fix critical crashes when recreating streams
- Fix MAVlink-related thread leak that leads to a crash or complete stall caused by thread starvation
- Helps #310 because it fixes a thread leak related to the Mavlink and stream recreation
- May helps #308



