### PR TITLE
Add video tee

### DIFF
--- a/src/stream/pipeline/fake_pipeline.rs
+++ b/src/stream/pipeline/fake_pipeline.rs
@@ -8,7 +8,8 @@ use crate::{
 };
 
 use super::{
-    PipelineGstreamerInterface, PipelineState, PIPELINE_FILTER_NAME, PIPELINE_SINK_TEE_NAME,
+    PipelineGstreamerInterface, PipelineState, PIPELINE_FILTER_NAME, PIPELINE_RTP_TEE_NAME,
+    PIPELINE_VIDEO_TEE_NAME,
 };
 
 use anyhow::{anyhow, Result};
@@ -57,7 +58,8 @@ impl FakePipeline {
         };
 
         let filter_name = format!("{PIPELINE_FILTER_NAME}-{pipeline_id}");
-        let sink_tee_name = format!("{PIPELINE_SINK_TEE_NAME}-{pipeline_id}");
+        let video_tee_name = format!("{PIPELINE_VIDEO_TEE_NAME}-{pipeline_id}");
+        let rtp_tee_name = format!("{PIPELINE_RTP_TEE_NAME}-{pipeline_id}");
 
         // Fakes (videotestsrc) are only "video/x-raw" or "video/x-bayer",
         // and to be able to encode it, we need to define an available
@@ -74,8 +76,9 @@ impl FakePipeline {
                         " ! x264enc tune=zerolatency speed-preset=ultrafast bitrate=5000",
                         " ! h264parse",
                         " ! capsfilter name={filter_name} caps=video/x-h264,profile={profile},stream-format=avc,alignment=au,width={width},height={height},framerate={interval_denominator}/{interval_numerator}",
+                        " ! tee name={video_tee_name} allow-not-linked=true",
                         " ! rtph264pay aggregate-mode=zero-latency config-interval=10 pt=96",
-                        " ! tee name={sink_tee_name} allow-not-linked=true"
+                        " ! tee name={rtp_tee_name} allow-not-linked=true"
                     ),
                     pattern = pattern,
                     profile = "constrained-baseline",
@@ -84,7 +87,8 @@ impl FakePipeline {
                     interval_denominator = configuration.frame_interval.denominator,
                     interval_numerator = configuration.frame_interval.numerator,
                     filter_name = filter_name,
-                    sink_tee_name = sink_tee_name,
+                    video_tee_name = video_tee_name,
+                    rtp_tee_name = rtp_tee_name,
                 )
             }
             VideoEncodeType::Yuyv => {
@@ -97,8 +101,9 @@ impl FakePipeline {
                         " ! timeoverlay",
                         " ! video/x-raw,format=I420",
                         " ! capsfilter name={filter_name} caps=video/x-raw,format=I420,width={width},height={height},framerate={interval_denominator}/{interval_numerator}",
+                        " ! tee name={video_tee_name} allow-not-linked=true",
                         " ! rtpvrawpay pt=96",
-                        " ! tee name={sink_tee_name} allow-not-linked=true",
+                        " ! tee name={rtp_tee_name} allow-not-linked=true",
                     ),
                     pattern = pattern,
                     width = configuration.width,
@@ -106,7 +111,8 @@ impl FakePipeline {
                     interval_denominator = configuration.frame_interval.denominator,
                     interval_numerator = configuration.frame_interval.numerator,
                     filter_name = filter_name,
-                    sink_tee_name = sink_tee_name,
+                    video_tee_name = video_tee_name,
+                    rtp_tee_name = rtp_tee_name,
                 )
             }
             VideoEncodeType::Mjpg => {
@@ -117,8 +123,9 @@ impl FakePipeline {
                         " ! video/x-raw,format=I420",
                         " ! jpegenc quality=85 idct-method=1",
                         " ! capsfilter name={filter_name} caps=image/jpeg,width={width},height={height},framerate={interval_denominator}/{interval_numerator}",
+                        " ! tee name={video_tee_name} allow-not-linked=true",
                         " ! rtpjpegpay pt=96",
-                        " ! tee name={sink_tee_name} allow-not-linked=true",
+                        " ! tee name={rtp_tee_name} allow-not-linked=true",
                     ),
                     pattern = pattern,
                     width = configuration.width,
@@ -126,7 +133,8 @@ impl FakePipeline {
                     interval_denominator = configuration.frame_interval.denominator,
                     interval_numerator = configuration.frame_interval.numerator,
                     filter_name = filter_name,
-                    sink_tee_name = sink_tee_name,
+                    video_tee_name = video_tee_name,
+                    rtp_tee_name = rtp_tee_name,
                 )
             }
             unsupported => {

--- a/src/stream/pipeline/redirect_pipeline.rs
+++ b/src/stream/pipeline/redirect_pipeline.rs
@@ -3,7 +3,7 @@ use crate::{
     video_stream::types::VideoAndStreamInformation,
 };
 
-use super::{PipelineGstreamerInterface, PipelineState, PIPELINE_SINK_TEE_NAME};
+use super::{PipelineGstreamerInterface, PipelineState, PIPELINE_RTP_TEE_NAME};
 
 use anyhow::{anyhow, Context, Result};
 
@@ -57,7 +57,7 @@ impl RedirectPipeline {
             .first()
             .context("Failed to access the fisrt endpoint")?;
 
-        let sink_tee_name = format!("{PIPELINE_SINK_TEE_NAME}-{pipeline_id}");
+        let sink_tee_name = format!("{PIPELINE_RTP_TEE_NAME}-{pipeline_id}");
 
         let description = match url.scheme() {
             "rtsp" => {

--- a/src/stream/sink/image_sink.rs
+++ b/src/stream/sink/image_sink.rs
@@ -332,8 +332,6 @@ impl ImageSink {
         let mut _transcoding_elements: Vec<gst::Element> = Default::default();
         match encoding {
             VideoEncodeType::H264 => {
-                let depayloader = gst::ElementFactory::make("rtph264depay").build()?;
-                let parser = gst::ElementFactory::make("h264parse").build()?;
                 // For h264, we need to filter-out unwanted non-key frames here, before decoding it.
                 let filter = gst::ElementFactory::make("identity")
                     .property("drop-buffer-flags", gst::BufferFlags::DELTA_UNIT)
@@ -343,24 +341,15 @@ impl ImageSink {
                     .property_from_str("lowres", "2") // (0) is 'full'; (1) is '1/2-size'; (2) is '1/4-size'
                     .build()?;
                 decoder.has_property("discard-corrupted-frames", None).then(|| decoder.set_property("discard-corrupted-frames", true));
-                _transcoding_elements.push(depayloader);
-                _transcoding_elements.push(parser);
                 _transcoding_elements.push(filter);
                 _transcoding_elements.push(decoder);
             }
             VideoEncodeType::Mjpg => {
-                let depayloader = gst::ElementFactory::make("rtpjpegdepay").build()?;
-                let parser = gst::ElementFactory::make("jpegparse").build()?;
                 let decoder = gst::ElementFactory::make("jpegdec").build()?;
                 decoder.has_property("discard-corrupted-frames", None).then(|| decoder.set_property("discard-corrupted-frames", true));
-                _transcoding_elements.push(depayloader);
-                _transcoding_elements.push(parser);
                 _transcoding_elements.push(decoder);
             }
-            VideoEncodeType::Yuyv => {
-                let depayloader = gst::ElementFactory::make("rtpvrawdepay").build()?;
-                _transcoding_elements.push(depayloader);
-            }
+            VideoEncodeType::Yuyv => {}
             _ => return Err(anyhow!("Unsupported video encoding for ImageSink: {encoding:?}. The supported are: H264, MJPG and YUYV")),
         };
 


### PR DESCRIPTION
This patch removes the need for some sinks (ImageSink for now, WebRTCSink in the future) to have to un an RTP depayloader and/or video parser.

It does so by adding a second Tee just before the payloader.

The older Tee, previously called "SinkTee", is now named "RTPTee", while the newer is called "VideoTee".

![image](https://github.com/mavlink/mavlink-camera-manager/assets/5920286/82c6ad1e-bc4a-48c3-ad09-0def962d3bd9)

Relates to #274.
