### PR TITLE
src: stream: pipeline: Fix wrong frame duration

### DIFF
--- a/src/stream/pipeline/v4l_pipeline.rs
+++ b/src/stream/pipeline/v4l_pipeline.rs
@@ -56,7 +56,7 @@ impl V4lPipeline {
             VideoEncodeType::H264 => {
                 format!(
                     concat!(
-                        "v4l2src device={device} do-timestamp=false",
+                        "v4l2src device={device} do-timestamp=true",
                         " ! h264parse",  // Here we need the parse to help the stream-format and alignment part, which is being fixed here because avc/au seems to reduce the CPU usage in the RTP payloading part.
                         " ! capsfilter name={filter_name} caps=video/x-h264,stream-format=avc,alignment=au,width={width},height={height},framerate={interval_denominator}/{interval_numerator}",
                         " ! tee name={video_tee_name} allow-not-linked=true",
@@ -76,7 +76,7 @@ impl V4lPipeline {
             VideoEncodeType::Yuyv => {
                 format!(
                     concat!(
-                        "v4l2src device={device} do-timestamp=false",
+                        "v4l2src device={device} do-timestamp=true",
                         " ! videoconvert",
                         " ! capsfilter name={filter_name} caps=video/x-raw,format=I420,width={width},height={height},framerate={interval_denominator}/{interval_numerator}",
                         " ! tee name={video_tee_name} allow-not-linked=true",
@@ -96,7 +96,7 @@ impl V4lPipeline {
             VideoEncodeType::Mjpg => {
                 format!(
                     concat!(
-                        "v4l2src device={device} do-timestamp=false",
+                        "v4l2src device={device} do-timestamp=true",
                         // We don't need a jpegparse, as it leads to incompatible caps, spoiling the negotiation.
                         " ! capsfilter name={filter_name} caps=image/jpeg,width={width},height={height},framerate={interval_denominator}/{interval_numerator}",
                         " ! tee name={video_tee_name} allow-not-linked=true",


### PR DESCRIPTION
This patch:
* Fixes the frame duration, which fixes the FPS reported from different applications when a video is recorded from our WebRTC.
* might help [this Cockpit issue](https://github.com/bluerobotics/cockpit/issues/794).

# Verification

## From `ffprobe`:
![image](https://github.com/mavlink/mavlink-camera-manager/assets/5920286/5ccccfd6-e724-4667-8e01-53a74921aec2)

## From `YUYView` (before):

### Stream Info for `before.webm`:
![image](https://github.com/mavlink/mavlink-camera-manager/assets/5920286/68fe4265-e270-49bd-9226-9285b73b2bdf)

### Stream Info for `before.mkv`:
![image](https://github.com/mavlink/mavlink-camera-manager/assets/5920286/868fb82e-5eea-45bb-9618-a7d2d017c0f8)

### Packet Analysis for `before.mkv`:
![image](https://github.com/mavlink/mavlink-camera-manager/assets/5920286/fbea44ca-8527-4f7c-9f7e-50f3d2458fc7)


## From `YUYView` (after):

### Stream Info for `after.webm`:
![image](https://github.com/mavlink/mavlink-camera-manager/assets/5920286/c9049159-7c71-4240-8095-3cedf10e46b4)

### Stream Info for `after.mkv`:
![image](https://github.com/mavlink/mavlink-camera-manager/assets/5920286/facc0ce0-2a4c-43ce-b939-b77ada1b5653)

### Packet Analysis for `after.mkv`:
![image](https://github.com/mavlink/mavlink-camera-manager/assets/5920286/a8c892d5-89b0-44d2-8a86-9ba7af5df561)

