### PR TITLE
stream: rtsp: Add TCP back in RTSP

### DIFF
--- a/src/stream/rtsp/rtsp_server.rs
+++ b/src/stream/rtsp/rtsp_server.rs
@@ -114,7 +114,8 @@ impl RTSPServer {
         factory.set_buffer_size(0);
         factory.set_latency(0u32);
         factory.set_transport_mode(RTSPTransportMode::PLAY);
-        factory.set_protocols(RTSPLowerTrans::UDP | RTSPLowerTrans::UDP_MCAST);
+        factory
+            .set_protocols(RTSPLowerTrans::UDP | RTSPLowerTrans::UDP_MCAST | RTSPLowerTrans::TCP);
 
         let Some(encode) = rtp_caps.iter().find_map(|structure| {
             structure.iter().find_map(|(key, sendvalue)| {


### PR DESCRIPTION
TCP is the default for RTSP, for current format, the user should use rtspu