### PR TITLE
Add rtsp protocol options via schemes

### DIFF
--- a/src/stream/pipeline/mod.rs
+++ b/src/stream/pipeline/mod.rs
@@ -204,7 +204,7 @@ impl PipelineState {
                 // In case it exisits, try to remove it first, but skip the result
                 let _ = RTSPServer::stop_pipeline(&sink.path());
 
-                RTSPServer::add_pipeline(&sink.path(), &sink.socket_path(), caps)?;
+                RTSPServer::add_pipeline(&sink.scheme(), &sink.path(), &sink.socket_path(), caps)?;
 
                 RTSPServer::start_pipeline(&sink.path())?;
             }

--- a/src/stream/rtsp/mod.rs
+++ b/src/stream/rtsp/mod.rs
@@ -1,1 +1,2 @@
+pub mod rtsp_scheme;
 pub mod rtsp_server;

--- a/src/stream/rtsp/rtsp_scheme.rs
+++ b/src/stream/rtsp/rtsp_scheme.rs
@@ -1,0 +1,58 @@
+#[derive(Default, Clone)]
+pub enum RTSPScheme {
+    #[default]
+    Rtsp,
+    Rtspu,
+    Rtspt,
+    Rtsph,
+    Rtsps,
+    Rtspsu,
+    Rtspst,
+    Rtspsh,
+}
+
+impl RTSPScheme {
+    pub const VALUES: [Self; 8] = [
+        Self::Rtsp,
+        Self::Rtspu,
+        Self::Rtspt,
+        Self::Rtsph,
+        Self::Rtsps,
+        Self::Rtspsu,
+        Self::Rtspst,
+        Self::Rtspsh,
+    ];
+}
+
+impl std::fmt::Debug for RTSPScheme {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::Rtsp => write!(f, "rtsp"),
+            Self::Rtspu => write!(f, "rtspu"),
+            Self::Rtspt => write!(f, "rtspt"),
+            Self::Rtsph => write!(f, "rtsph"),
+            Self::Rtsps => write!(f, "rtsps"),
+            Self::Rtspsu => write!(f, "rtspsu"),
+            Self::Rtspst => write!(f, "rtspst"),
+            Self::Rtspsh => write!(f, "rtspsh"),
+        }
+    }
+}
+
+impl TryFrom<&str> for RTSPScheme {
+    type Error = String;
+
+    fn try_from(value: &str) -> std::prelude::v1::Result<Self, Self::Error> {
+        match value.to_lowercase().as_str() {
+            "rtsp" => Ok(Self::Rtsp),
+            "rtspu" => Ok(Self::Rtspu),
+            "rtspt" => Ok(Self::Rtspt),
+            "rtsph" => Ok(Self::Rtsph),
+            "rtsps" => Ok(Self::Rtsps),
+            "rtspsu" => Ok(Self::Rtspsu),
+            "rtspst" => Ok(Self::Rtspst),
+            "rtspsh" => Ok(Self::Rtspsh),
+            _ => Err("Uknown RTSP scheme variant".to_string()),
+        }
+    }
+}


### PR DESCRIPTION
Tested and working with both `rtspsrc` and ffplay:

- [x] `rtsp://` -> both UDP and TCP
- [x] `rtspu://` -> UDP
- [x] `rtspt://` -> TCP
- [x] `rtsph://` -> TCP tunneled via HTTP
- [x] `rtspth://` -> TCP w/ TLS
- [x] `rtspuh://` -> UDP w/ TLS
- [x] `rtspsh://` -> TCP tunneled via HTTP w/ TSL

Note: a drawback of this approach is that despite the scheme used in the endpoint, the RTSP client would always use `rtsp://` instead.