### PR TITLE
Add support to QrTimeStamp plugin

### DIFF
--- a/src/stream/gst/utils.rs
+++ b/src/stream/gst/utils.rs
@@ -8,20 +8,24 @@ pub struct PluginRankConfig {
 }
 
 #[allow(dead_code)] // TODO: Use this to check all used plugins are available
-pub fn is_gst_plugin_available(plugin_name: &str, min_version: &str) -> bool {
+pub fn is_gst_plugin_available(plugin_name: &str, min_version: Option<&str>) -> bool {
     // reference: https://github.com/GStreamer/gst/blob/b4ca58df7624b005a33e182a511904d7cceea890/tools/gst-inspect.c#L2148
 
     if let Err(error) = gst::init() {
         tracing::error!("Error! {error}");
     }
 
-    let version = semver::Version::parse(min_version).unwrap();
-    gst::Registry::get().check_feature_version(
-        plugin_name,
-        version.major.try_into().unwrap(),
-        version.minor.try_into().unwrap(),
-        version.patch.try_into().unwrap(),
-    )
+    if let Some(min_version) = min_version {
+        let version = semver::Version::parse(min_version).unwrap();
+        gst::Registry::get().check_feature_version(
+            plugin_name,
+            version.major.try_into().unwrap(),
+            version.minor.try_into().unwrap(),
+            version.patch.try_into().unwrap(),
+        )
+    } else {
+        gst::Registry::get().lookup_feature(plugin_name).is_some()
+    }
 }
 
 pub fn set_plugin_rank(plugin_name: &str, rank: gst::Rank) -> Result<()> {

--- a/src/stream/pipeline/fake_pipeline.rs
+++ b/src/stream/pipeline/fake_pipeline.rs
@@ -43,7 +43,7 @@ impl FakePipeline {
             VideoSourceType::Gst(source) => source,
             unsupported => {
                 return Err(anyhow!(
-                    "SourceType {unsupported:?} is not supported as Fake Pipeline"
+                    "VideoSourceType {unsupported:?} is not supported as Fake Pipeline"
                 ))
             }
         };
@@ -52,7 +52,7 @@ impl FakePipeline {
             VideoSourceGstType::Fake(pattern) => pattern,
             unsupported => {
                 return Err(anyhow!(
-                    "SourceType {unsupported:?} is not supported as Fake Pipeline"
+                    "VideoSourceGstType {unsupported:?} is not supported as Fake Pipeline"
                 ))
             }
         };

--- a/src/stream/pipeline/qr_pipeline.rs
+++ b/src/stream/pipeline/qr_pipeline.rs
@@ -1,0 +1,129 @@
+use crate::{
+    stream::types::CaptureConfiguration,
+    video::{
+        types::{VideoEncodeType, VideoSourceType},
+        video_source_gst::VideoSourceGstType,
+    },
+    video_stream::types::VideoAndStreamInformation,
+};
+
+use super::{
+    PipelineGstreamerInterface, PipelineState, PIPELINE_FILTER_NAME, PIPELINE_RTP_TEE_NAME,
+    PIPELINE_VIDEO_TEE_NAME,
+};
+
+use anyhow::{anyhow, Result};
+
+use tracing::*;
+
+use gst::prelude::*;
+
+#[derive(Debug)]
+pub struct QrPipeline {
+    pub state: PipelineState,
+}
+
+impl QrPipeline {
+    #[instrument(level = "debug")]
+    pub fn try_new(
+        pipeline_id: &uuid::Uuid,
+        video_and_stream_information: &VideoAndStreamInformation,
+    ) -> Result<gst::Pipeline> {
+        let configuration = match &video_and_stream_information
+            .stream_information
+            .configuration
+        {
+            CaptureConfiguration::Video(configuration) => configuration,
+            unsupported => {
+                return Err(anyhow!(
+                    "{unsupported:?} is not supported as QrTimeStamp Pipeline"
+                ))
+            }
+        };
+
+        let video_source = match &video_and_stream_information.video_source {
+            VideoSourceType::Gst(source) => source,
+            unsupported => {
+                return Err(anyhow!(
+                    "VideoSourceType {unsupported:?} is not supported as QrTimeStamp Pipeline"
+                ))
+            }
+        };
+
+        let _pattern = match &video_source.source {
+            VideoSourceGstType::QR(pattern) => pattern,
+            unsupported => {
+                return Err(anyhow!(
+                    "VideoSourceGstType {unsupported:?} is not supported as QrTimeStamp Pipeline"
+                ))
+            }
+        };
+
+        let filter_name = format!("{PIPELINE_FILTER_NAME}-{pipeline_id}");
+        let video_tee_name = format!("{PIPELINE_VIDEO_TEE_NAME}-{pipeline_id}");
+        let rtp_tee_name = format!("{PIPELINE_RTP_TEE_NAME}-{pipeline_id}");
+
+        let description = match &configuration.encode {
+            VideoEncodeType::H264 => {
+                format!(concat!(
+                        "qrtimestampsrc",
+                        " ! video/x-raw,width={width},height={height},framerate={interval_denominator}/{interval_numerator}",
+                        " ! videoconvert",
+                        " ! x264enc tune=zerolatency speed-preset=ultrafast bitrate=5000",
+                        " ! h264parse",
+                        " ! capsfilter name={filter_name} caps=video/x-h264,profile={profile},stream-format=avc,alignment=au,width={width},height={height},framerate={interval_denominator}/{interval_numerator}",
+                        " ! tee name={video_tee_name} allow-not-linked=true",
+                        " ! rtph264pay aggregate-mode=zero-latency config-interval=10 pt=96",
+                        " ! tee name={rtp_tee_name} allow-not-linked=true"
+                    ),
+                    profile = "constrained-baseline",
+                    width = configuration.width,
+                    height = configuration.height,
+                    interval_denominator = configuration.frame_interval.denominator,
+                    interval_numerator = configuration.frame_interval.numerator,
+                    filter_name = filter_name,
+                    video_tee_name = video_tee_name,
+                    rtp_tee_name = rtp_tee_name,
+                )
+            }
+            VideoEncodeType::Rgb => {
+                format!(
+                    concat!(
+                        "qrtimestampsrc",
+                        " ! video/x-raw,width={width},height={height},framerate={interval_denominator}/{interval_numerator}",
+                        " ! tee name={video_tee_name} allow-not-linked=true",
+                        " ! rtpvrawpay pt=96",
+                        " ! tee name={rtp_tee_name} allow-not-linked=true",
+                    ),
+                    width = configuration.width,
+                    height = configuration.height,
+                    interval_denominator = configuration.frame_interval.denominator,
+                    interval_numerator = configuration.frame_interval.numerator,
+                    video_tee_name = video_tee_name,
+                    rtp_tee_name = rtp_tee_name,
+                )
+            }
+            unsupported => {
+                return Err(anyhow!(
+                    "Encode {unsupported:?} is not supported for Test Pipeline"
+                ))
+            }
+        };
+
+        debug!("pipeline_description: {description:#?}");
+        let pipeline = gst::parse::launch(&description)?;
+
+        let pipeline = pipeline
+            .downcast::<gst::Pipeline>()
+            .expect("Couldn't downcast pipeline");
+
+        Ok(pipeline)
+    }
+}
+
+impl PipelineGstreamerInterface for QrPipeline {
+    #[instrument(level = "trace")]
+    fn is_running(&self) -> bool {
+        self.state.pipeline_runner.is_running()
+    }
+}

--- a/src/stream/sink/image_sink.rs
+++ b/src/stream/sink/image_sink.rs
@@ -362,6 +362,7 @@ impl ImageSink {
                 decoder.has_property("discard-corrupted-frames", None).then(|| decoder.set_property("discard-corrupted-frames", true));
                 _transcoding_elements.push(decoder);
             }
+            VideoEncodeType::Rgb => {}
             VideoEncodeType::Yuyv => {}
             _ => return Err(anyhow!("Unsupported video encoding for ImageSink: {encoding:?}. The supported are: H264, MJPG and YUYV")),
         };

--- a/src/video/types.rs
+++ b/src/video/types.rs
@@ -19,6 +19,7 @@ pub enum VideoEncodeType {
     H264,
     H265,
     Mjpg,
+    Rgb,
     Unknown(String),
     Yuyv,
 }


### PR DESCRIPTION
To receive RGB:
```
gst-launch-1.0 -v udpsrc address=0.0.0.0 port=5602 close-socket=false auto-multicast=true \
    caps="application/x-rtp, sampling=(string)RGB, width=(string)320, height=(string)320, payload=(int)96" \
    ! rtpvrawdepay ! videoconvert ! fpsdisplaysink sync=false
```
To Receive H264:
```
gst-launch-1.0 udpsrc port=5602 caps='application/x-rtp, media=(string)video, clock-rate=(int)90000, encoding-name=(string)H264' ! rtph264depay ! avdec_h264 ! clockoverlay valignment=bottom ! autovideosink sync=true
```