### PR TITLE
src: lib: stream: Improve RTSP latency

### DIFF
--- a/src/lib/stream/rtsp/rtsp_server.rs
+++ b/src/lib/stream/rtsp/rtsp_server.rs
@@ -165,7 +165,7 @@ impl RTSPServer {
             "H264" => {
                 format!(
                     concat!(
-                        "shmsrc socket-path={socket_path} do-timestamp=true is-live=true",
+                        "shmsrc socket-path={socket_path} do-timestamp=true is-live=false",
                         " ! queue leaky=downstream flush-on-eos=true silent=true max-size-buffers=0",
                         " ! capsfilter caps={rtp_caps:?}",
                         " ! rtph264depay",
@@ -178,7 +178,7 @@ impl RTSPServer {
             "RAW" => {
                 format!(
                     concat!(
-                        "shmsrc socket-path={socket_path} do-timestamp=true is-live=true",
+                        "shmsrc socket-path={socket_path} do-timestamp=true is-live=false",
                         " ! queue leaky=downstream flush-on-eos=true silent=true max-size-buffers=0",
                         " ! capsfilter caps={rtp_caps:?}",
                         " ! rtpvrawdepay",
@@ -191,7 +191,7 @@ impl RTSPServer {
             "JPEG" => {
                 format!(
                     concat!(
-                        "shmsrc socket-path={socket_path} do-timestamp=true is-live=true",
+                        "shmsrc socket-path={socket_path} do-timestamp=true is-live=false",
                         " ! queue leaky=downstream flush-on-eos=true silent=true max-size-buffers=10",
                         " ! capsfilter caps={rtp_caps:?}",
                         " ! rtpjpegdepay",

--- a/src/lib/stream/sink/rtsp_sink.rs
+++ b/src/lib/stream/sink/rtsp_sink.rs
@@ -251,7 +251,7 @@ impl RtspSink {
         let socket_path = format!("/tmp/{id}");
         let sink = gst::ElementFactory::make("shmsink")
             .property_from_str("socket-path", &socket_path)
-            .property("sync", true)
+            .property("sync", false)
             .property("wait-for-connection", true)
             .property("shm-size", 10_000_000u32)
             .property("enable-last-sample", false)


### PR DESCRIPTION
The `is-live=true` in `shmsrc` was adding ~1 frame of latency, while the `sync=true` in `shmsink` was adding more ~2.


tested:
- [x] locally (Linux)
- [x] BlueOS @ Raspberry Pi 4

How to test:
1. Create a QrTimestamp 320x320@30fps RTSP stream as below:
![image](https://github.com/user-attachments/assets/d369857d-e563-4805-8e28-bcb4ef3b1f5d)

2. To receive it, run the following line:
```
clear; GST_DEBUG="*:3,*qrtimestampsink*:5" gst-launch-1.0 -v \
    rtspsrc location=rtsp://192.168.100.2:8554/test is-live=true latency=0 \
    ! application/x-rtp,payload=96 \
    ! rtph264depay \
    ! h264parse \
    ! avdec_h264 discard-corrupted-frames=true \
    ! videoconvert \
    ! qrtimestampsink
```

Before this patch (master), the expected latency is ~100 ms. 
After this patch it is ~34 ms (which is the same as the UDP)