### PR TITLE
src: lib: stream: sink: shmsink doesn't need to wait

### DIFF
--- a/src/lib/stream/sink/rtsp_sink.rs
+++ b/src/lib/stream/sink/rtsp_sink.rs
@@ -252,7 +252,7 @@ impl RtspSink {
         let sink = gst::ElementFactory::make("shmsink")
             .property_from_str("socket-path", &socket_path)
             .property("sync", false)
-            .property("wait-for-connection", true)
+            .property("wait-for-connection", false)
             .property("shm-size", 10_000_000u32)
             .property("enable-last-sample", false)
             .build()?;


### PR DESCRIPTION
This helps with stability when creating raw RTSP streams.

- tested both locally (Linux) and on BlueOS