### PR TITLE
Fix verbosity

### DIFF
--- a/src/lib/controls/onvif/manager.rs
+++ b/src/lib/controls/onvif/manager.rs
@@ -48,7 +48,7 @@ impl Manager {
         use std::net::{IpAddr, Ipv4Addr};
 
         loop {
-            debug!("Discovering onvif...");
+            trace!("Discovering onvif...");
 
             const MAX_CONCURRENT_JUMPERS: usize = 100;
 

--- a/src/lib/logger/manager.rs
+++ b/src/lib/logger/manager.rs
@@ -33,8 +33,8 @@ pub fn init() {
         .with_line_number(true)
         .with_span_events(fmt::format::FmtSpan::NONE)
         .with_target(false)
-        .with_thread_ids(true)
-        .with_thread_names(true)
+        .with_thread_ids(false)
+        .with_thread_names(false)
         .with_filter(console_env_filter);
 
     // Configure the file log

--- a/src/lib/mavlink/manager.rs
+++ b/src/lib/mavlink/manager.rs
@@ -114,7 +114,7 @@ impl Manager {
                     continue;
                 }
 
-                debug!("Message accepted: {header:?}, {message:?}");
+                trace!("Message accepted: {header:?}, {message:?}");
 
                 // Send the received message to the cameras
                 if let Err(error) = inner_guard


### PR DESCRIPTION
To see again those messages:
```
export RUST_LOG=debug,mavlink_camera_manager::controls::onvif=trace,mavlink_camera_manager::mavlink=trace
```

note: a more fine-grained control is also possible if needed

Closes #443
Closes #51