### PR TITLE
Add h265 support - Part II: Onvif

### DIFF
--- a/src/lib/controls/onvif/mod.rs
+++ b/src/lib/controls/onvif/mod.rs
@@ -1,2 +1,2 @@
-mod client;
+pub mod camera;
 pub mod manager;

--- a/src/lib/custom/bluerov.rs
+++ b/src/lib/custom/bluerov.rs
@@ -4,22 +4,31 @@ use url::Url;
 use crate::{
     network::utils::get_visible_qgc_address,
     stream::types::*,
-    video::{self, types::*, video_source::VideoSourceAvailable},
+    video::{
+        self,
+        types::*,
+        video_source::{VideoSourceAvailable, VideoSourceFormats},
+    },
     video_stream::types::VideoAndStreamInformation,
 };
 
 async fn get_cameras_with_encode_type(encode: VideoEncodeType) -> Vec<VideoSourceType> {
+    let mut result = Vec::new();
+
     let cameras = video::video_source_local::VideoSourceLocal::cameras_available().await;
-    cameras
-        .iter()
-        .filter(move |cam| {
-            cam.inner()
-                .formats()
-                .iter()
-                .any(|format| format.encode == encode)
-        })
-        .cloned()
-        .collect()
+
+    for camera in cameras.iter() {
+        if camera
+            .formats()
+            .await
+            .iter()
+            .any(|format| format.encode == encode)
+        {
+            result.push(camera.clone());
+        }
+    }
+
+    result
 }
 
 fn sort_sizes(sizes: &mut [Size]) {
@@ -29,91 +38,117 @@ fn sort_sizes(sizes: &mut [Size]) {
     });
 }
 
-pub fn udp() -> Vec<VideoAndStreamInformation> {
-    get_cameras_with_encode_type(VideoEncodeType::H264)
-        .iter()
-        .enumerate()
-        .filter_map(|(index, cam)| {
-            let formats = cam.inner().formats();
-            let Some(format) = formats
-                .iter()
-                .find(|format| format.encode == VideoEncodeType::H264)
-            else {
-                warn!("Unable to find a valid format for {cam:?}");
-                return None;
-            };
+pub async fn udp() -> Vec<VideoAndStreamInformation> {
+    let mut result = Vec::new();
 
-            // Get the biggest resolution possible
-            let mut sizes = format.sizes.clone();
-            sort_sizes(&mut sizes);
+    let sources = get_cameras_with_encode_type(VideoEncodeType::H264).await;
 
-            let Some(size) = sizes.last() else {
-                warn!("Unable to find a valid size for {cam:?}");
-                return None;
-            };
+    for (index, source) in sources.iter().enumerate() {
+        let formats = source.formats().await;
 
-            Some(VideoAndStreamInformation {
-                name: format!("UDP Stream {}", index),
-                stream_information: StreamInformation {
-                    endpoints: vec![
-                        Url::parse(&format!("udp://192.168.2.1:{}", 5600 + index)).ok()?
-                    ],
-                    configuration: CaptureConfiguration::Video(VideoCaptureConfiguration {
-                        encode: format.encode.clone(),
-                        height: size.height,
-                        width: size.width,
-                        frame_interval: size.intervals.first()?.clone(),
-                    }),
-                    extended_configuration: None,
-                },
-                video_source: cam.clone(),
-            })
+        let Some(format) = formats
+            .iter()
+            .find(|format| format.encode == VideoEncodeType::H264)
+        else {
+            warn!("Unable to find a valid format for {source:?}");
+            continue;
+        };
+
+        // Get the biggest resolution possible
+        let mut sizes = format.sizes.clone();
+        sort_sizes(&mut sizes);
+        let Some(size) = sizes.last() else {
+            warn!("Unable to find a valid size for {source:?}");
+            continue;
+        };
+
+        let Some(frame_interval) = size.intervals.first().cloned() else {
+            warn!("Unable to find a frame interval");
+            continue;
+        };
+
+        let endpoint = match Url::parse(&format!("udp://192.168.2.1:{}", 5600 + index)) {
+            Ok(url) => url,
+            Err(error) => {
+                warn!("Failed to parse URL: {error:?}");
+                continue;
+            }
+        };
+
+        result.push(VideoAndStreamInformation {
+            name: format!("UDP Stream {index}"),
+            stream_information: StreamInformation {
+                endpoints: vec![endpoint],
+                configuration: CaptureConfiguration::Video(VideoCaptureConfiguration {
+                    encode: format.encode.clone(),
+                    height: size.height,
+                    width: size.width,
+                    frame_interval,
+                }),
+                extended_configuration: None,
+            },
+            video_source: source.clone(),
         })
-        .collect()
+    }
+
+    result
 }
 
-pub fn rtsp() -> Vec<VideoAndStreamInformation> {
-    get_cameras_with_encode_type(VideoEncodeType::H264)
-        .iter()
-        .enumerate()
-        .filter_map(|(index, cam)| {
-            let formats = cam.inner().formats();
-            let Some(format) = formats
-                .iter()
-                .find(|format| format.encode == VideoEncodeType::H264)
-            else {
-                warn!("Unable to find a valid format for {cam:?}");
-                return None;
-            };
+pub async fn rtsp() -> Vec<VideoAndStreamInformation> {
+    let mut result = Vec::new();
 
-            // Get the biggest resolution possible
-            let mut sizes = format.sizes.clone();
-            sort_sizes(&mut sizes);
+    let sources = get_cameras_with_encode_type(VideoEncodeType::H264).await;
 
-            let Some(size) = sizes.last() else {
-                warn!("Unable to find a valid size for {cam:?}");
-                return None;
-            };
+    for (index, source) in sources.iter().enumerate() {
+        let formats = source.formats().await;
 
-            let visible_qgc_ip_address = get_visible_qgc_address();
+        let Some(format) = formats
+            .iter()
+            .find(|format| format.encode == VideoEncodeType::H264)
+        else {
+            warn!("Unable to find a valid format for {source:?}");
+            continue;
+        };
 
-            Some(VideoAndStreamInformation {
-                name: format!("RTSP Stream {index}"),
-                stream_information: StreamInformation {
-                    endpoints: vec![Url::parse(&format!(
-                        "rtsp://{visible_qgc_ip_address}:8554/video_{index}"
-                    ))
-                    .ok()?],
-                    configuration: CaptureConfiguration::Video(VideoCaptureConfiguration {
-                        encode: format.encode.clone(),
-                        height: size.height,
-                        width: size.width,
-                        frame_interval: size.intervals.first()?.clone(),
-                    }),
-                    extended_configuration: None,
-                },
-                video_source: cam.clone(),
-            })
-        })
-        .collect()
+        // Get the biggest resolution possible
+        let mut sizes = format.sizes.clone();
+        sort_sizes(&mut sizes);
+        let Some(size) = sizes.last() else {
+            warn!("Unable to find a valid size for {source:?}");
+            continue;
+        };
+
+        let Some(frame_interval) = size.intervals.first().cloned() else {
+            warn!("Unable to find a frame interval");
+            continue;
+        };
+
+        let visible_qgc_ip_address = get_visible_qgc_address();
+        let endpoint = match Url::parse(&format!(
+            "rtsp://{visible_qgc_ip_address}:8554/video_{index}"
+        )) {
+            Ok(url) => url,
+            Err(error) => {
+                warn!("Failed to parse URL: {error:?}");
+                continue;
+            }
+        };
+
+        result.push(VideoAndStreamInformation {
+            name: format!("RTSP Stream {index}"),
+            stream_information: StreamInformation {
+                endpoints: vec![endpoint],
+                configuration: CaptureConfiguration::Video(VideoCaptureConfiguration {
+                    encode: format.encode.clone(),
+                    height: size.height,
+                    width: size.width,
+                    frame_interval,
+                }),
+                extended_configuration: None,
+            },
+            video_source: source.clone(),
+        });
+    }
+
+    result
 }

--- a/src/lib/custom/bluerov.rs
+++ b/src/lib/custom/bluerov.rs
@@ -8,8 +8,8 @@ use crate::{
     video_stream::types::VideoAndStreamInformation,
 };
 
-fn get_cameras_with_encode_type(encode: VideoEncodeType) -> Vec<VideoSourceType> {
-    let cameras = video::video_source_local::VideoSourceLocal::cameras_available();
+async fn get_cameras_with_encode_type(encode: VideoEncodeType) -> Vec<VideoSourceType> {
+    let cameras = video::video_source_local::VideoSourceLocal::cameras_available().await;
     cameras
         .iter()
         .filter(move |cam| {

--- a/src/lib/custom/mod.rs
+++ b/src/lib/custom/mod.rs
@@ -13,10 +13,10 @@ pub enum CustomEnvironment {
     WebRTCTest,
 }
 
-pub fn create_default_streams() -> Vec<VideoAndStreamInformation> {
+pub async fn create_default_streams() -> Vec<VideoAndStreamInformation> {
     match cli::manager::default_settings() {
-        Some(CustomEnvironment::BlueROVUDP) => bluerov::udp(),
-        Some(CustomEnvironment::BlueROVRTSP) => bluerov::rtsp(),
+        Some(CustomEnvironment::BlueROVUDP) => bluerov::udp().await,
+        Some(CustomEnvironment::BlueROVRTSP) => bluerov::rtsp().await,
         Some(CustomEnvironment::WebRTCTest) => test::take_webrtc_stream(),
         _ => vec![],
     }

--- a/src/lib/logger/manager.rs
+++ b/src/lib/logger/manager.rs
@@ -10,21 +10,13 @@ pub fn init() {
     LogTracer::init_with_filter(tracing::log::LevelFilter::Trace).expect("Failed to set logger");
 
     // Configure the console log
-    let console_env_filter = EnvFilter::try_from_default_env()
-        .unwrap_or_else(|_| {
-            if cli::manager::is_verbose() {
-                EnvFilter::new(LevelFilter::DEBUG.to_string())
-            } else {
-                EnvFilter::new(LevelFilter::INFO.to_string())
-            }
-        })
-        // Hyper is used for http request by our thread leak test
-        // And it's pretty verbose when it's on
-        .add_directive("hyper=off".parse().unwrap())
-        // Reducing onvif-related libs verbosity
-        .add_directive("yaserde=off".parse().unwrap())
-        .add_directive("ws_discovery=off".parse().unwrap())
-        .add_directive("onvif::discovery=off".parse().unwrap());
+    let console_env_filter = EnvFilter::try_from_default_env().unwrap_or_else(|_| {
+        if cli::manager::is_verbose() {
+            EnvFilter::new(LevelFilter::DEBUG.to_string())
+        } else {
+            EnvFilter::new(LevelFilter::INFO.to_string())
+        }
+    });
 
     let console_layer = fmt::Layer::new()
         .with_writer(std::io::stdout)
@@ -35,7 +27,7 @@ pub fn init() {
         .with_target(false)
         .with_thread_ids(false)
         .with_thread_names(false)
-        .with_filter(console_env_filter);
+        .with_filter(filter_unwanted_crates(console_env_filter));
 
     // Configure the file log
     let file_env_filter = if cli::manager::is_tracing() {
@@ -54,7 +46,7 @@ pub fn init() {
         .with_target(false)
         .with_thread_ids(true)
         .with_thread_names(true)
-        .with_filter(file_env_filter);
+        .with_filter(filter_unwanted_crates(file_env_filter));
 
     // Configure the default subscriber
     match cli::manager::is_tracy() {
@@ -145,4 +137,58 @@ fn redirect_gstreamer_logs_to_tracing() {
             );
         },
     );
+}
+
+fn filter_unwanted_crates(env_filter: EnvFilter) -> EnvFilter {
+    env_filter
+        // Hyper is used for http request by our thread leak test
+        // And it's pretty verbose when it's on
+        .add_directive("hyper=off".parse().unwrap())
+        // Reducing onvif-related libs verbosity
+        .add_directive("yaserde=off".parse().unwrap())
+        .add_directive("reqwest=off".parse().unwrap())
+        .add_directive("onvif=off".parse().unwrap())
+        .add_directive("schema=off".parse().unwrap())
+        .add_directive("transport=off".parse().unwrap())
+        .add_directive("validate=off".parse().unwrap())
+        .add_directive("common=off".parse().unwrap())
+        .add_directive("metadatastream=off".parse().unwrap())
+        .add_directive("onvif_xsd=off".parse().unwrap())
+        .add_directive("radiometry=off".parse().unwrap())
+        .add_directive("rules=off".parse().unwrap())
+        .add_directive("soap_envelope=off".parse().unwrap())
+        .add_directive("types=off".parse().unwrap())
+        .add_directive("xmlmime=off".parse().unwrap())
+        .add_directive("xop=off".parse().unwrap())
+        .add_directive("accesscontrol=off".parse().unwrap())
+        .add_directive("accessrules=off".parse().unwrap())
+        .add_directive("actionengine=off".parse().unwrap())
+        .add_directive("advancedsecurity=off".parse().unwrap())
+        .add_directive("analytics=off".parse().unwrap())
+        .add_directive("authenticationbehavior=off".parse().unwrap())
+        .add_directive("b_2=off".parse().unwrap())
+        .add_directive("bf_2=off".parse().unwrap())
+        .add_directive("credential=off".parse().unwrap())
+        .add_directive("deviceio=off".parse().unwrap())
+        .add_directive("devicemgmt=off".parse().unwrap())
+        .add_directive("display=off".parse().unwrap())
+        .add_directive("doorcontrol=off".parse().unwrap())
+        .add_directive("event=off".parse().unwrap())
+        .add_directive("imaging=off".parse().unwrap())
+        .add_directive("media=off".parse().unwrap())
+        .add_directive("media2=off".parse().unwrap())
+        .add_directive("provisioning=off".parse().unwrap())
+        .add_directive("ptz=off".parse().unwrap())
+        .add_directive("receiver=off".parse().unwrap())
+        .add_directive("recording=off".parse().unwrap())
+        .add_directive("replay=off".parse().unwrap())
+        .add_directive("schedule=off".parse().unwrap())
+        .add_directive("search=off".parse().unwrap())
+        .add_directive("t_1=off".parse().unwrap())
+        .add_directive("thermal=off".parse().unwrap())
+        .add_directive("uplink=off".parse().unwrap())
+        .add_directive("ws_addr=off".parse().unwrap())
+        .add_directive("ws_discovery=off".parse().unwrap())
+        .add_directive("xml_xsd=off".parse().unwrap())
+        .add_directive("onvif::discovery=off".parse().unwrap())
 }

--- a/src/lib/mavlink/mavlink_camera.rs
+++ b/src/lib/mavlink/mavlink_camera.rs
@@ -393,7 +393,7 @@ impl MavlinkCameraInner {
                 send_ack(&sender, our_header, their_header, data.command, result);
 
                 let source_string = camera.video_source_type.inner().source_string();
-                let result = match crate::video::video_source::reset_controls(source_string) {
+                let result = match crate::video::video_source::reset_controls(source_string).await {
                     Ok(_) => mavlink::common::MavResult::MAV_RESULT_ACCEPTED,
                     Err(error) => {
                         error!("Failed to reset {source_string:?} controls with its default values as {:#?}:{:#?}. Reason: {error:?}", our_header.system_id, our_header.component_id);

--- a/src/lib/server/pages.rs
+++ b/src/lib/server/pages.rs
@@ -204,6 +204,12 @@ pub async fn v4l() -> Json<Vec<ApiVideoSource>> {
                     formats: gst.formats().await,
                     controls: gst.controls(),
                 },
+                VideoSourceType::Onvif(onvif) => ApiVideoSource {
+                    name: onvif.name().clone(),
+                    source: onvif.source_string().to_string(),
+                    formats: onvif.formats().await,
+                    controls: onvif.controls(),
+                },
                 VideoSourceType::Redirect(redirect) => ApiVideoSource {
                     name: redirect.name().clone(),
                     source: redirect.source_string().to_string(),

--- a/src/lib/server/pages.rs
+++ b/src/lib/server/pages.rs
@@ -185,7 +185,7 @@ pub async fn info() -> CreatedJson<Info> {
 #[api_v2_operation]
 /// Provides list of all video sources, with controls and formats
 pub async fn v4l() -> Json<Vec<ApiVideoSource>> {
-    let cameras = video_source::cameras_available();
+    let cameras = video_source::cameras_available().await;
     let cameras: Vec<ApiVideoSource> = cameras
         .iter()
         .map(|cam| match cam {
@@ -365,7 +365,7 @@ pub fn camera_reset_controls(json: web::Json<ResetCameraControls>) -> HttpRespon
 /// Provides a xml description file that contains information for a specific device, based on: https://mavlink.io/en/services/camera_def.html
 pub fn xml(xml_file_request: web::Query<XmlFileRequest>) -> HttpResponse {
     debug!("{xml_file_request:#?}");
-    let cameras = video_source::cameras_available();
+    let cameras = video_source::cameras_available().await;
     let camera = cameras
         .iter()
         .find(|source| source.inner().source_string() == xml_file_request.file);

--- a/src/lib/server/pages.rs
+++ b/src/lib/server/pages.rs
@@ -16,7 +16,7 @@ use crate::{
     stream::{gst as gst_stream, manager as stream_manager, types::StreamInformation},
     video::{
         types::{Format, VideoSourceType},
-        video_source::{self, VideoSource},
+        video_source::{self, VideoSource, VideoSourceFormats},
         xml,
     },
     video_stream::types::VideoAndStreamInformation,
@@ -186,38 +186,43 @@ pub async fn info() -> CreatedJson<Info> {
 /// Provides list of all video sources, with controls and formats
 pub async fn v4l() -> Json<Vec<ApiVideoSource>> {
     let cameras = video_source::cameras_available().await;
-    let cameras: Vec<ApiVideoSource> = cameras
-        .iter()
-        .map(|cam| match cam {
-            VideoSourceType::Local(cam) => ApiVideoSource {
-                name: cam.name().clone(),
-                source: cam.source_string().to_string(),
-                formats: cam.formats(),
-                controls: cam.controls(),
-            },
-            VideoSourceType::Gst(gst) => ApiVideoSource {
-                name: gst.name().clone(),
-                source: gst.source_string().to_string(),
-                formats: gst.formats(),
-                controls: gst.controls(),
-            },
-            VideoSourceType::Redirect(redirect) => ApiVideoSource {
-                name: redirect.name().clone(),
-                source: redirect.source_string().to_string(),
-                formats: redirect.formats(),
-                controls: redirect.controls(),
-            },
+
+    use futures::stream::{self, StreamExt};
+
+    let cameras: Vec<ApiVideoSource> = stream::iter(cameras)
+        .then(|cam| async {
+            match cam {
+                VideoSourceType::Local(local) => ApiVideoSource {
+                    name: local.name().clone(),
+                    source: local.source_string().to_string(),
+                    formats: local.formats().await,
+                    controls: local.controls(),
+                },
+                VideoSourceType::Gst(gst) => ApiVideoSource {
+                    name: gst.name().clone(),
+                    source: gst.source_string().to_string(),
+                    formats: gst.formats().await,
+                    controls: gst.controls(),
+                },
+                VideoSourceType::Redirect(redirect) => ApiVideoSource {
+                    name: redirect.name().clone(),
+                    source: redirect.source_string().to_string(),
+                    formats: redirect.formats().await,
+                    controls: redirect.controls(),
+                },
+            }
         })
-        .collect();
+        .collect()
+        .await;
 
     Json(cameras)
 }
 
 #[api_v2_operation]
 /// Change video control for a specific source
-pub fn v4l_post(json: web::Json<V4lControl>) -> HttpResponse {
+pub async fn v4l_post(json: web::Json<V4lControl>) -> HttpResponse {
     let control = json.into_inner();
-    let answer = video_source::set_control(&control.device, control.v4l_id, control.value);
+    let answer = video_source::set_control(&control.device, control.v4l_id, control.value).await;
 
     if let Err(error) = answer {
         return HttpResponse::NotAcceptable()
@@ -232,7 +237,7 @@ pub fn v4l_post(json: web::Json<V4lControl>) -> HttpResponse {
 /// Reset service settings
 pub async fn reset_settings(query: web::Query<ResetSettings>) -> HttpResponse {
     if query.all.unwrap_or_default() {
-        settings::manager::reset();
+        settings::manager::reset().await;
         if let Err(error) = stream_manager::start_default().await {
             return HttpResponse::InternalServerError()
                 .content_type("text/plain")
@@ -273,7 +278,7 @@ pub async fn streams() -> HttpResponse {
 pub async fn streams_post(json: web::Json<PostStream>) -> HttpResponse {
     let json = json.into_inner();
 
-    let video_source = match video_source::get_video_source(&json.source) {
+    let video_source = match video_source::get_video_source(&json.source).await {
         Ok(video_source) => video_source,
         Err(error) => {
             return HttpResponse::NotAcceptable()
@@ -329,7 +334,7 @@ pub fn remove_stream(query: web::Query<RemoveStream>) -> HttpResponse {
 #[api_v2_operation]
 /// Reset controls from a given camera source
 pub fn camera_reset_controls(json: web::Json<ResetCameraControls>) -> HttpResponse {
-    if let Err(errors) = video_source::reset_controls(&json.device) {
+    if let Err(errors) = video_source::reset_controls(&json.device).await {
         let mut error: String = Default::default();
         errors
             .iter()

--- a/src/lib/stream/manager.rs
+++ b/src/lib/stream/manager.rs
@@ -116,7 +116,7 @@ pub async fn start_default() -> Result<()> {
     remove_all_streams().await?;
 
     // Update all local video sources to make sure that they are available
-    let mut candidates = video_source::cameras_available();
+    let mut candidates = video_source::cameras_available().await;
     update_devices(&mut streams, &mut candidates, true);
 
     // Remove all invalid video_sources

--- a/src/lib/stream/manager.rs
+++ b/src/lib/stream/manager.rs
@@ -117,7 +117,7 @@ pub async fn start_default() -> Result<()> {
 
     // Update all local video sources to make sure that they are available
     let mut candidates = video_source::cameras_available().await;
-    update_devices(&mut streams, &mut candidates, true);
+    update_devices(&mut streams, &mut candidates, true).await;
 
     // Remove all invalid video_sources
     let streams: Vec<VideoAndStreamInformation> = streams
@@ -137,7 +137,7 @@ pub async fn start_default() -> Result<()> {
 }
 
 #[instrument(level = "debug")]
-pub fn update_devices(
+pub async fn update_devices(
     streams: &mut Vec<VideoAndStreamInformation>,
     candidates: &mut Vec<VideoSourceType>,
     verbose: bool,
@@ -152,7 +152,10 @@ pub fn update_devices(
             continue;
         };
 
-        match source.try_identify_device(capture_configuration, candidates) {
+        match source
+            .try_identify_device(capture_configuration, candidates)
+            .await
+        {
             Ok(Some(candidate_source_string)) => {
                 let Some((idx, candidate)) =
                     candidates.iter().enumerate().find_map(|(idx, candidate)| {

--- a/src/lib/stream/mod.rs
+++ b/src/lib/stream/mod.rs
@@ -139,7 +139,7 @@ impl Stream {
                         std::time::Instant::now() - last_report_time >= report_interval;
 
                     // Find the best candidate
-                    manager::update_devices(&mut streams, &mut candidates, should_report);
+                    manager::update_devices(&mut streams, &mut candidates, should_report).await;
                     video_and_stream_information = streams.first().unwrap().clone();
 
                     // Check if the chosen video source is available
@@ -148,7 +148,9 @@ impl Stream {
                             .video_source
                             .inner()
                             .source_string(),
-                    ) {
+                    )
+                    .await
+                    {
                         Ok(best_candidate) => {
                             video_and_stream_information.video_source = best_candidate;
                         }

--- a/src/lib/stream/mod.rs
+++ b/src/lib/stream/mod.rs
@@ -120,7 +120,7 @@ impl Stream {
                 // If it's a camera, try to update the device
                 if let VideoSourceType::Local(_) = video_and_stream_information.video_source {
                     let mut streams = vec![video_and_stream_information.clone()];
-                    let mut candidates = cameras_available();
+                    let mut candidates = cameras_available().await;
 
                     // Discards any source from other running streams, otherwise we'd be trying to create a stream from a device in use (which is not possible)
                     let current_running_streams = manager::streams()

--- a/src/lib/stream/pipeline/mod.rs
+++ b/src/lib/stream/pipeline/mod.rs
@@ -1,4 +1,5 @@
 pub mod fake_pipeline;
+pub mod onvif_pipeline;
 pub mod qr_pipeline;
 pub mod redirect_pipeline;
 pub mod runner;
@@ -23,6 +24,7 @@ use crate::{
 };
 
 use fake_pipeline::FakePipeline;
+use onvif_pipeline::OnvifPipeline;
 use qr_pipeline::QrPipeline;
 use redirect_pipeline::RedirectPipeline;
 use runner::PipelineRunner;
@@ -42,6 +44,7 @@ pub enum Pipeline {
     V4l(V4lPipeline),
     Fake(FakePipeline),
     QR(QrPipeline),
+    Onvif(OnvifPipeline),
     Redirect(RedirectPipeline),
 }
 
@@ -52,6 +55,7 @@ impl Pipeline {
             Pipeline::V4l(pipeline) => &mut pipeline.state,
             Pipeline::Fake(pipeline) => &mut pipeline.state,
             Pipeline::QR(pipeline) => &mut pipeline.state,
+            Pipeline::Onvif(pipeline) => &mut pipeline.state,
             Pipeline::Redirect(pipeline) => &mut pipeline.state,
         }
     }
@@ -62,6 +66,7 @@ impl Pipeline {
             Pipeline::V4l(pipeline) => &pipeline.state,
             Pipeline::Fake(pipeline) => &pipeline.state,
             Pipeline::QR(pipeline) => &pipeline.state,
+            Pipeline::Onvif(pipeline) => &pipeline.state,
             Pipeline::Redirect(pipeline) => &pipeline.state,
         }
     }
@@ -93,6 +98,9 @@ impl Pipeline {
             }),
             #[cfg(not(target_os = "linux"))]
             VideoSourceType::Local(_) => unreachable!("Local is only supported on linux"),
+            VideoSourceType::Onvif(_) => Pipeline::Onvif(OnvifPipeline {
+                state: pipeline_state,
+            }),
             VideoSourceType::Redirect(_) => Pipeline::Redirect(RedirectPipeline {
                 state: pipeline_state,
             }),
@@ -148,6 +156,9 @@ impl PipelineState {
             #[cfg(not(target_os = "linux"))]
             VideoSourceType::Local(_) => {
                 unreachable!("Local source only supported on linux");
+            }
+            VideoSourceType::Onvif(_) => {
+                OnvifPipeline::try_new(pipeline_id, video_and_stream_information)
             }
             VideoSourceType::Redirect(_) => {
                 RedirectPipeline::try_new(pipeline_id, video_and_stream_information)

--- a/src/lib/stream/pipeline/mod.rs
+++ b/src/lib/stream/pipeline/mod.rs
@@ -271,7 +271,7 @@ impl PipelineState {
         );
 
         let sink = self.sinks.remove(sink_id).context(format!(
-            "Failed to remove sink {sink_id} from Sinks of the Pipeline {pipeline_id}"
+            "Sink {sink_id} not found in Pipeline {pipeline_id}"
         ))?;
 
         // Terminate the Sink

--- a/src/lib/stream/pipeline/onvif_pipeline.rs
+++ b/src/lib/stream/pipeline/onvif_pipeline.rs
@@ -1,0 +1,128 @@
+use anyhow::{anyhow, Result};
+use gst::prelude::*;
+use tracing::*;
+
+use crate::{
+    stream::types::CaptureConfiguration,
+    video::{
+        types::{VideoEncodeType, VideoSourceType},
+        video_source_onvif::VideoSourceOnvifType,
+    },
+    video_stream::types::VideoAndStreamInformation,
+};
+
+use super::{
+    PipelineGstreamerInterface, PipelineState, PIPELINE_FILTER_NAME, PIPELINE_RTP_TEE_NAME,
+    PIPELINE_VIDEO_TEE_NAME,
+};
+
+#[derive(Debug)]
+pub struct OnvifPipeline {
+    pub state: PipelineState,
+}
+
+impl OnvifPipeline {
+    #[instrument(level = "debug")]
+    pub fn try_new(
+        pipeline_id: &uuid::Uuid,
+        video_and_stream_information: &VideoAndStreamInformation,
+    ) -> Result<gst::Pipeline> {
+        match &video_and_stream_information
+            .stream_information
+            .configuration
+        {
+            CaptureConfiguration::Video(configuration) => configuration,
+            unsupported => {
+                return Err(anyhow!(
+                    "{unsupported:?} is not supported as Onvif Pipeline"
+                ))
+            }
+        };
+
+        let video_source = match &video_and_stream_information.video_source {
+            VideoSourceType::Onvif(source) => source,
+            unsupported => {
+                return Err(anyhow!(
+                    "SourceType {unsupported:?} is not supported as V4l Pipeline"
+                ))
+            }
+        };
+
+        let location = {
+            let VideoSourceOnvifType::Onvif(url) = &video_source.source;
+            url.to_string()
+        };
+
+        let encode = match &video_and_stream_information
+            .stream_information
+            .configuration
+        {
+            CaptureConfiguration::Video(configuration) => Some(configuration.encode.clone()),
+            _unknown => None,
+        };
+
+        let filter_name = format!("{PIPELINE_FILTER_NAME}-{pipeline_id}");
+        let video_tee_name = format!("{PIPELINE_VIDEO_TEE_NAME}-{pipeline_id}");
+        let rtp_tee_name = format!("{PIPELINE_RTP_TEE_NAME}-{pipeline_id}");
+
+        let description = match encode {
+            Some(VideoEncodeType::H264) => {
+                format!(
+                    concat!(
+                        "rtspsrc location={location} is-live=true latency=0",
+                        " ! application/x-rtp",
+                        " ! rtph264depay",
+                        // " ! h264parse", // we might want to add this in the future to expand the compatibility, since it can transform the stream format
+                        " ! capsfilter name={filter_name} caps=video/x-h264,stream-format=avc,alignment=au",
+                        " ! tee name={video_tee_name} allow-not-linked=true",
+                        " ! rtph264pay aggregate-mode=zero-latency config-interval=10 pt=96",
+                        " ! tee name={rtp_tee_name} allow-not-linked=true"
+                    ),
+                    location = location,
+                    filter_name = filter_name,
+                    video_tee_name = video_tee_name,
+                    rtp_tee_name = rtp_tee_name,
+                )
+            }
+            Some(VideoEncodeType::H265) => {
+                format!(
+                    concat!(
+                        "rtspsrc location={location} is-live=true latency=0",
+                        " ! application/x-rtp",
+                        " ! rtph265depay",
+                        // " ! h265parse", // we might want to add this in the future to expand the compatibility, since it can transform the stream format
+                        " ! capsfilter name={filter_name} caps=video/x-h265,profile={profile},stream-format=byte-stream,alignment=au",
+                        " ! tee name={video_tee_name} allow-not-linked=true",
+                        " ! rtph265pay aggregate-mode=zero-latency config-interval=10 pt=96",
+                        " ! tee name={rtp_tee_name} allow-not-linked=true"
+                    ),
+                    location = location,
+                    filter_name = filter_name,
+                    video_tee_name = video_tee_name,
+                    profile = "main",
+                    rtp_tee_name = rtp_tee_name,
+                )
+            }
+            unsupported => {
+                return Err(anyhow!(
+                    "Encode {unsupported:?} is not supported for Onvif Pipeline"
+                ))
+            }
+        };
+
+        let pipeline = gst::parse::launch(&description)?;
+
+        let pipeline = pipeline
+            .downcast::<gst::Pipeline>()
+            .expect("Couldn't downcast pipeline");
+
+        Ok(pipeline)
+    }
+}
+
+impl PipelineGstreamerInterface for OnvifPipeline {
+    #[instrument(level = "trace")]
+    fn is_running(&self) -> bool {
+        self.state.pipeline_runner.is_running()
+    }
+}

--- a/src/lib/stream/webrtc/signalling_server.rs
+++ b/src/lib/stream/webrtc/signalling_server.rs
@@ -292,9 +292,9 @@ impl SignallingServer {
                 let (height, width, encode, interval) =
                     match &stream.video_and_stream.stream_information.configuration {
                         crate::stream::types::CaptureConfiguration::Video(configuration) => {
-                            // Filter out non-H264 local streams
-                            if configuration.encode != crate::video::types::VideoEncodeType::H264 {
-                                trace!("Stream {:?} will not be listed in available streams because it's encoding isn't H264 (it's {:?} instead)", stream.video_and_stream.name, configuration.encode);
+                            // Filter out non-H264/h265 local streams
+                            if !matches!(configuration.encode, crate::video::types::VideoEncodeType::H264 | crate::video::types::VideoEncodeType::H265) {
+                                trace!("Stream {:?} will not be listed in available streams because it's encoding isn't H264 or H265 (it's {:?} instead)", stream.video_and_stream.name, configuration.encode);
                                 return None;
                             }
                             (

--- a/src/lib/stream/webrtc/signalling_server.rs
+++ b/src/lib/stream/webrtc/signalling_server.rs
@@ -125,10 +125,10 @@ impl SignallingServer {
 
                             if let Err(error) = stream::Manager::remove_session(&bind, reason).await
                             {
-                                error!("Failed removing session {bind:?}. Reason: {error}",);
+                                error!("Failed removing session: {bind:?}. Reason: {error}",);
                             }
 
-                            info!("Session {bind:?} ended by consumer");
+                            info!("Session: {bind:?} ended by consumer");
                             continue;
                         }
 

--- a/src/lib/video/local/video_source_local_linux.rs
+++ b/src/lib/video/local/video_source_local_linux.rs
@@ -9,11 +9,13 @@ use regex::Regex;
 use serde::{Deserialize, Serialize};
 use tracing::*;
 
-use crate::video::video_source::VideoSourceAvailable;
 use crate::{
     controls::types::*,
     stream::types::VideoCaptureConfiguration,
-    video::{types::*, video_source::VideoSource},
+    video::{
+        types::*,
+        video_source::{VideoSource, VideoSourceAvailable, VideoSourceFormats},
+    },
 };
 
 lazy_static! {
@@ -321,16 +323,8 @@ fn validate_control(control: &Control, value: i64) -> Result<(), String> {
     Ok(())
 }
 
-impl VideoSource for VideoSourceLocal {
-    fn name(&self) -> &String {
-        &self.name
-    }
-
-    fn source_string(&self) -> &str {
-        &self.device_path
-    }
-
-    fn formats(&self) -> Vec<Format> {
+impl VideoSourceFormats for VideoSourceLocal {
+    async fn formats(&self) -> Vec<Format> {
         let device_path = self.device_path.clone();
         let typ = self.typ.clone();
 
@@ -481,6 +475,16 @@ impl VideoSource for VideoSourceLocal {
                 .insert(device_path.to_string(), formats.clone());
             formats
         })
+    }
+}
+
+impl VideoSource for VideoSourceLocal {
+    fn name(&self) -> &String {
+        &self.name
+    }
+
+    fn source_string(&self) -> &str {
+        &self.device_path
     }
 
     fn set_control_by_name(&self, control_name: &str, value: i64) -> std::io::Result<()> {

--- a/src/lib/video/local/video_source_local_linux.rs
+++ b/src/lib/video/local/video_source_local_linux.rs
@@ -687,7 +687,7 @@ impl VideoSource for VideoSourceLocal {
 }
 
 impl VideoSourceAvailable for VideoSourceLocal {
-    fn cameras_available() -> Vec<VideoSourceType> {
+    async fn cameras_available() -> Vec<VideoSourceType> {
         let mut cameras: Vec<VideoSourceType> = vec![];
 
         let cameras_path = {

--- a/src/lib/video/local/video_source_local_none.rs
+++ b/src/lib/video/local/video_source_local_none.rs
@@ -21,7 +21,7 @@ pub struct VideoSourceLocal {
 }
 
 impl VideoSourceLocal {
-    pub fn try_identify_device(
+    pub async fn try_identify_device(
         &mut self,
         capture_configuration: &VideoCaptureConfiguration,
         candidates: &[VideoSourceType],

--- a/src/lib/video/local/video_source_local_none.rs
+++ b/src/lib/video/local/video_source_local_none.rs
@@ -84,8 +84,8 @@ impl VideoSource for VideoSourceLocal {
     }
 }
 
-impl VideoSourceAvailable for VideoSourceLocal {
-    fn cameras_available() -> Vec<VideoSourceType> {
+impl VideoSourceLocal {
+    pub async fn cameras_available() -> Vec<VideoSourceType> {
         return vec![];
     }
 }

--- a/src/lib/video/local/video_source_local_none.rs
+++ b/src/lib/video/local/video_source_local_none.rs
@@ -7,7 +7,7 @@ use crate::{
     stream::types::VideoCaptureConfiguration,
     video::{
         types::*,
-        video_source::{VideoSource, VideoSourceAvailable},
+        video_source::{VideoSource, VideoSourceAvailable, VideoSourceFormats},
     },
 };
 
@@ -30,6 +30,12 @@ impl VideoSourceLocal {
     }
 }
 
+impl VideoSourceFormats for VideoSourceLocal {
+    async fn formats(&self) -> Vec<Format> {
+        vec![]
+    }
+}
+
 impl VideoSource for VideoSourceLocal {
     fn name(&self) -> &String {
         &self.name
@@ -37,10 +43,6 @@ impl VideoSource for VideoSourceLocal {
 
     fn source_string(&self) -> &str {
         &self.device_path
-    }
-
-    fn formats(&self) -> Vec<Format> {
-        return vec![];
     }
 
     fn set_control_by_name(&self, _control_name: &str, _value: i64) -> std::io::Result<()> {

--- a/src/lib/video/local/video_source_local_none.rs
+++ b/src/lib/video/local/video_source_local_none.rs
@@ -84,8 +84,8 @@ impl VideoSource for VideoSourceLocal {
     }
 }
 
-impl VideoSourceLocal {
-    pub async fn cameras_available() -> Vec<VideoSourceType> {
+impl VideoSourceAvailable for VideoSourceLocal {
+    async fn cameras_available() -> Vec<VideoSourceType> {
         return vec![];
     }
 }

--- a/src/lib/video/mod.rs
+++ b/src/lib/video/mod.rs
@@ -6,4 +6,5 @@ pub mod xml;
 
 pub mod video_source_gst;
 pub mod video_source_local;
+pub mod video_source_onvif;
 pub mod video_source_redirect;

--- a/src/lib/video/types.rs
+++ b/src/lib/video/types.rs
@@ -3,8 +3,10 @@ use paperclip::actix::Apiv2Schema;
 use serde::{Deserialize, Serialize};
 
 use super::{
-    video_source::VideoSource, video_source_gst::VideoSourceGst,
-    video_source_local::VideoSourceLocal, video_source_redirect::VideoSourceRedirect,
+    video_source::{VideoSource, VideoSourceFormats},
+    video_source_gst::VideoSourceGst,
+    video_source_local::VideoSourceLocal,
+    video_source_redirect::VideoSourceRedirect,
 };
 
 #[derive(Apiv2Schema, Clone, Debug, PartialEq, Serialize, Deserialize)]
@@ -59,6 +61,17 @@ impl VideoSourceType {
             VideoSourceType::Local(local) => local,
             VideoSourceType::Gst(gst) => gst,
             VideoSourceType::Redirect(redirect) => redirect,
+        }
+    }
+}
+
+impl VideoSourceFormats for VideoSourceType {
+    async fn formats(&self) -> Vec<Format> {
+        match self {
+            VideoSourceType::Gst(gst) => gst.formats().await,
+            VideoSourceType::Local(local) => local.formats().await,
+            VideoSourceType::Onvif(onvif) => onvif.formats().await,
+            VideoSourceType::Redirect(redirect) => redirect.formats().await,
         }
     }
 }

--- a/src/lib/video/types.rs
+++ b/src/lib/video/types.rs
@@ -6,6 +6,7 @@ use super::{
     video_source::{VideoSource, VideoSourceFormats},
     video_source_gst::VideoSourceGst,
     video_source_local::VideoSourceLocal,
+    video_source_onvif::VideoSourceOnvif,
     video_source_redirect::VideoSourceRedirect,
 };
 
@@ -13,6 +14,7 @@ use super::{
 pub enum VideoSourceType {
     Gst(VideoSourceGst),
     Local(VideoSourceLocal),
+    Onvif(VideoSourceOnvif),
     Redirect(VideoSourceRedirect),
 }
 
@@ -60,6 +62,7 @@ impl VideoSourceType {
         match self {
             VideoSourceType::Local(local) => local,
             VideoSourceType::Gst(gst) => gst,
+            VideoSourceType::Onvif(onvif) => onvif,
             VideoSourceType::Redirect(redirect) => redirect,
         }
     }

--- a/src/lib/video/video_source.rs
+++ b/src/lib/video/video_source.rs
@@ -24,17 +24,17 @@ pub(crate) trait VideoSourceAvailable {
     async fn cameras_available() -> Vec<VideoSourceType>;
 }
 
-pub fn cameras_available() -> Vec<VideoSourceType> {
+pub async fn cameras_available() -> Vec<VideoSourceType> {
     [
-        &VideoSourceLocal::cameras_available()[..],
-        &VideoSourceGst::cameras_available()[..],
-        &VideoSourceRedirect::cameras_available()[..],
+        &VideoSourceLocal::cameras_available().await[..],
+        &VideoSourceGst::cameras_available().await[..],
+        &VideoSourceRedirect::cameras_available().await[..],
     ]
     .concat()
 }
 
-pub fn get_video_source(source_string: &str) -> Result<VideoSourceType, std::io::Error> {
-    let cameras = cameras_available();
+pub async fn get_video_source(source_string: &str) -> Result<VideoSourceType, std::io::Error> {
+    let cameras = cameras_available().await;
 
     if let Some(camera) = cameras
         .iter()
@@ -102,8 +102,8 @@ pub fn reset_controls(source_string: &str) -> Result<(), Vec<std::io::Error>> {
 mod tests {
     use super::*;
 
-    #[test]
-    fn simple_test() {
-        println!("{:#?}", cameras_available());
+    #[tokio::test]
+    async fn simple_test() {
+        println!("{:#?}", cameras_available().await);
     }
 }

--- a/src/lib/video/video_source.rs
+++ b/src/lib/video/video_source.rs
@@ -10,7 +10,6 @@ use super::{
 pub trait VideoSource {
     fn name(&self) -> &String;
     fn source_string(&self) -> &str;
-    fn formats(&self) -> Vec<Format>;
     fn set_control_by_name(&self, control_name: &str, value: i64) -> std::io::Result<()>;
     fn set_control_by_id(&self, control_id: u64, value: i64) -> std::io::Result<()>;
     fn control_value_by_name(&self, control_name: &str) -> std::io::Result<i64>;
@@ -18,6 +17,10 @@ pub trait VideoSource {
     fn controls(&self) -> Vec<Control>;
     fn is_valid(&self) -> bool;
     fn is_shareable(&self) -> bool;
+}
+
+pub(crate) trait VideoSourceFormats {
+    async fn formats(&self) -> Vec<Format>;
 }
 
 pub(crate) trait VideoSourceAvailable {

--- a/src/lib/video/video_source.rs
+++ b/src/lib/video/video_source.rs
@@ -59,14 +59,14 @@ pub async fn get_video_source(source_string: &str) -> Result<VideoSourceType, st
     ))
 }
 
-pub fn set_control(source_string: &str, control_id: u64, value: i64) -> std::io::Result<()> {
-    let camera = get_video_source(source_string)?;
+pub async fn set_control(source_string: &str, control_id: u64, value: i64) -> std::io::Result<()> {
+    let camera = get_video_source(source_string).await?;
     debug!("Set camera ({source_string}) control ({control_id}) value ({value}).");
     return camera.inner().set_control_by_id(control_id, value);
 }
 
-pub fn reset_controls(source_string: &str) -> Result<(), Vec<std::io::Error>> {
-    let camera = match get_video_source(source_string) {
+pub async fn reset_controls(source_string: &str) -> Result<(), Vec<std::io::Error>> {
+    let camera = match get_video_source(source_string).await {
         Ok(camera) => camera,
         Err(error) => return Err(vec![error]),
     };

--- a/src/lib/video/video_source.rs
+++ b/src/lib/video/video_source.rs
@@ -4,7 +4,7 @@ use crate::controls::types::{Control, ControlType};
 
 use super::{
     types::*, video_source_gst::VideoSourceGst, video_source_local::VideoSourceLocal,
-    video_source_redirect::VideoSourceRedirect,
+    video_source_onvif::VideoSourceOnvif, video_source_redirect::VideoSourceRedirect,
 };
 
 pub trait VideoSource {
@@ -31,6 +31,7 @@ pub async fn cameras_available() -> Vec<VideoSourceType> {
     [
         &VideoSourceLocal::cameras_available().await[..],
         &VideoSourceGst::cameras_available().await[..],
+        &VideoSourceOnvif::cameras_available().await[..],
         &VideoSourceRedirect::cameras_available().await[..],
     ]
     .concat()

--- a/src/lib/video/video_source.rs
+++ b/src/lib/video/video_source.rs
@@ -20,8 +20,8 @@ pub trait VideoSource {
     fn is_shareable(&self) -> bool;
 }
 
-pub trait VideoSourceAvailable {
-    fn cameras_available() -> Vec<VideoSourceType>;
+pub(crate) trait VideoSourceAvailable {
+    async fn cameras_available() -> Vec<VideoSourceType>;
 }
 
 pub fn cameras_available() -> Vec<VideoSourceType> {

--- a/src/lib/video/video_source_gst.rs
+++ b/src/lib/video/video_source_gst.rs
@@ -5,7 +5,7 @@ use crate::{controls::types::Control, stream::gst::utils::is_gst_plugin_availabl
 
 use super::{
     types::*,
-    video_source::{VideoSource, VideoSourceAvailable},
+    video_source::{VideoSource, VideoSourceAvailable, VideoSourceFormats},
     video_source_local::VideoSourceLocal,
 };
 
@@ -23,22 +23,10 @@ pub struct VideoSourceGst {
     pub source: VideoSourceGstType,
 }
 
-impl VideoSource for VideoSourceGst {
-    fn name(&self) -> &String {
-        &self.name
-    }
-
-    fn source_string(&self) -> &str {
+impl VideoSourceFormats for VideoSourceGst {
+    async fn formats(&self) -> Vec<Format> {
         match &self.source {
-            VideoSourceGstType::Local(local) => local.source_string(),
-            VideoSourceGstType::Fake(string) => string,
-            VideoSourceGstType::QR(string) => string,
-        }
-    }
-
-    fn formats(&self) -> Vec<Format> {
-        match &self.source {
-            VideoSourceGstType::Local(local) => local.formats(),
+            VideoSourceGstType::Local(local) => local.formats().await,
             VideoSourceGstType::Fake(_) => {
                 let intervals: Vec<FrameInterval> = [60, 30, 24, 16, 10, 5]
                     .iter()
@@ -126,6 +114,20 @@ impl VideoSource for VideoSourceGst {
                     },
                 ]
             }
+        }
+    }
+}
+
+impl VideoSource for VideoSourceGst {
+    fn name(&self) -> &String {
+        &self.name
+    }
+
+    fn source_string(&self) -> &str {
+        match &self.source {
+            VideoSourceGstType::Local(local) => local.source_string(),
+            VideoSourceGstType::Fake(string) => string,
+            VideoSourceGstType::QR(string) => string,
         }
     }
 

--- a/src/lib/video/video_source_gst.rs
+++ b/src/lib/video/video_source_gst.rs
@@ -181,7 +181,7 @@ impl VideoSource for VideoSourceGst {
 }
 
 impl VideoSourceAvailable for VideoSourceGst {
-    fn cameras_available() -> Vec<VideoSourceType> {
+    async fn cameras_available() -> Vec<VideoSourceType> {
         let mut sources = vec![VideoSourceType::Gst(VideoSourceGst {
             name: "Fake source".into(),
             source: VideoSourceGstType::Fake("ball".into()),

--- a/src/lib/video/video_source_onvif.rs
+++ b/src/lib/video/video_source_onvif.rs
@@ -1,0 +1,89 @@
+use paperclip::actix::Apiv2Schema;
+use serde::{Deserialize, Serialize};
+
+use crate::controls::{onvif::manager::Manager as OnvifManager, types::Control};
+
+use super::{
+    types::*,
+    video_source::{VideoSource, VideoSourceAvailable, VideoSourceFormats},
+};
+
+#[derive(Apiv2Schema, Debug, Clone, PartialEq, Serialize, Deserialize)]
+pub enum VideoSourceOnvifType {
+    Onvif(String),
+}
+
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+pub struct VideoSourceOnvif {
+    pub name: String,
+    pub source: VideoSourceOnvifType,
+}
+
+impl VideoSourceFormats for VideoSourceOnvif {
+    async fn formats(&self) -> Vec<Format> {
+        let VideoSourceOnvifType::Onvif(stream_uri) = &self.source;
+        OnvifManager::get_formats(stream_uri)
+            .await
+            .unwrap_or_default()
+    }
+}
+
+impl VideoSource for VideoSourceOnvif {
+    fn name(&self) -> &String {
+        &self.name
+    }
+
+    fn source_string(&self) -> &str {
+        match &self.source {
+            VideoSourceOnvifType::Onvif(url) => url.as_str(),
+        }
+    }
+
+    fn set_control_by_name(&self, _control_name: &str, _value: i64) -> std::io::Result<()> {
+        Err(std::io::Error::new(
+            std::io::ErrorKind::NotFound,
+            "Onvif source doesn't have controls.",
+        ))
+    }
+
+    fn set_control_by_id(&self, _control_id: u64, _value: i64) -> std::io::Result<()> {
+        Err(std::io::Error::new(
+            std::io::ErrorKind::NotFound,
+            "Onvif source doesn't have controls.",
+        ))
+    }
+
+    fn control_value_by_name(&self, _control_name: &str) -> std::io::Result<i64> {
+        Err(std::io::Error::new(
+            std::io::ErrorKind::NotFound,
+            "Onvif source doesn't have controls.",
+        ))
+    }
+
+    fn control_value_by_id(&self, _control_id: u64) -> std::io::Result<i64> {
+        Err(std::io::Error::new(
+            std::io::ErrorKind::NotFound,
+            "Onvif source doesn't have controls.",
+        ))
+    }
+
+    fn controls(&self) -> Vec<Control> {
+        vec![]
+    }
+
+    fn is_valid(&self) -> bool {
+        match &self.source {
+            VideoSourceOnvifType::Onvif(_) => true,
+        }
+    }
+
+    fn is_shareable(&self) -> bool {
+        true
+    }
+}
+
+impl VideoSourceAvailable for VideoSourceOnvif {
+    async fn cameras_available() -> Vec<VideoSourceType> {
+        OnvifManager::streams_available().await.clone()
+    }
+}

--- a/src/lib/video/video_source_redirect.rs
+++ b/src/lib/video/video_source_redirect.rs
@@ -5,7 +5,7 @@ use crate::controls::types::Control;
 
 use super::{
     types::*,
-    video_source::{VideoSource, VideoSourceAvailable},
+    video_source::{VideoSource, VideoSourceAvailable, VideoSourceFormats},
 };
 
 #[derive(Apiv2Schema, Clone, Debug, PartialEq, Serialize, Deserialize)]
@@ -19,6 +19,16 @@ pub struct VideoSourceRedirect {
     pub source: VideoSourceRedirectType,
 }
 
+impl VideoSourceFormats for VideoSourceRedirect {
+    async fn formats(&self) -> Vec<Format> {
+        match &self.source {
+            VideoSourceRedirectType::Redirect(_) => {
+                vec![]
+            }
+        }
+    }
+}
+
 impl VideoSource for VideoSourceRedirect {
     fn name(&self) -> &String {
         &self.name
@@ -27,14 +37,6 @@ impl VideoSource for VideoSourceRedirect {
     fn source_string(&self) -> &str {
         match &self.source {
             VideoSourceRedirectType::Redirect(string) => string,
-        }
-    }
-
-    fn formats(&self) -> Vec<Format> {
-        match &self.source {
-            VideoSourceRedirectType::Redirect(_) => {
-                vec![]
-            }
         }
     }
 

--- a/src/lib/video/video_source_redirect.rs
+++ b/src/lib/video/video_source_redirect.rs
@@ -82,7 +82,7 @@ impl VideoSource for VideoSourceRedirect {
 }
 
 impl VideoSourceAvailable for VideoSourceRedirect {
-    fn cameras_available() -> Vec<VideoSourceType> {
+    async fn cameras_available() -> Vec<VideoSourceType> {
         vec![VideoSourceType::Redirect(VideoSourceRedirect {
             name: "Redirect source".into(),
             source: VideoSourceRedirectType::Redirect("Redirect".into()),

--- a/src/lib/video/xml.rs
+++ b/src/lib/video/xml.rs
@@ -198,10 +198,10 @@ mod tests {
 
     use super::*;
 
-    #[test]
-    fn test_device() {
+    #[tokio::test]
+    async fn test_device() {
         use crate::video::video_source;
-        for camera in video_source::cameras_available() {
+        for camera in video_source::cameras_available().await {
             if let VideoSourceType::Local(camera) = camera {
                 let xml_string = from_video_source(&camera).unwrap();
                 println!("{}", xml_string);

--- a/src/main.rs
+++ b/src/main.rs
@@ -9,7 +9,7 @@ async fn main() -> Result<(), std::io::Error> {
     // Logger should start before everything else to register any log information
     logger::manager::init();
     // Settings should start before everybody else to ensure that the CLI are stored
-    settings::manager::init(Some(&cli::manager::settings_file()));
+    settings::manager::init(Some(&cli::manager::settings_file())).await;
 
     controls::onvif::manager::Manager::init();
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -11,7 +11,7 @@ async fn main() -> Result<(), std::io::Error> {
     // Settings should start before everybody else to ensure that the CLI are stored
     settings::manager::init(Some(&cli::manager::settings_file())).await;
 
-    controls::onvif::manager::Manager::init();
+    controls::onvif::manager::Manager::init().await;
 
     mavlink::manager::Manager::init();
 


### PR DESCRIPTION
With this patch, Onvif is now a Video Source, and also a Pipeline, allowing the same API and workflow as for v4l cameras, which means we have all sinks support: UDP/RTSP/Thumbnail/WebRTC.