### PR TITLE
Improve Redirect to WebRTC compatibility

### DIFF
--- a/src/lib/controls/onvif/camera.rs
+++ b/src/lib/controls/onvif/camera.rs
@@ -8,7 +8,7 @@ use serde::{Deserialize, Serialize};
 use tokio::sync::RwLock;
 use tracing::*;
 
-use crate::{stream::gst::utils::get_encode_from_rtspsrc, video::types::Format};
+use crate::{stream::gst::utils::get_encode_from_stream_uri, video::types::Format};
 
 use super::manager::OnvifDevice;
 
@@ -243,7 +243,7 @@ impl OnvifCamera {
                 trace!("Using credentials {credentials:?}");
             }
 
-            let Some(encode) = get_encode_from_rtspsrc(&stream_uri).await else {
+            let Some(encode) = get_encode_from_stream_uri(&stream_uri).await else {
                 warn!("Failed getting encoding from RTSP stream at {stream_uri}");
                 continue;
             };

--- a/src/lib/stream/gst/utils.rs
+++ b/src/lib/stream/gst/utils.rs
@@ -1,5 +1,6 @@
 use anyhow::{anyhow, Result};
 use gst::prelude::*;
+use tokio::sync::mpsc;
 use tracing::*;
 
 use crate::video::types::VideoEncodeType;
@@ -110,32 +111,63 @@ pub async fn wait_for_element_state_async(
 }
 
 #[instrument(level = "debug")]
-pub async fn get_encode_from_rtspsrc(stream_uri: &url::Url) -> Option<VideoEncodeType> {
+pub async fn get_encode_from_stream_uri(stream_uri: &url::Url) -> Option<VideoEncodeType> {
     use gst::prelude::*;
 
-    let description = format!(
-        concat!(
-            "rtspsrc location={location} is-live=true latency=0",
-            " ! fakesink name=fakesink sync=false"
-        ),
-        location = stream_uri.to_string(),
-    );
+    let description = match stream_uri.scheme() {
+        "rtsp" => {
+            format!(
+                concat!(
+                    "rtspsrc location={location} is-live=true latency=0",
+                    " ! typefind name=typefinder minimum=1",
+                    " ! fakesink name=fakesink sync=false"
+                ),
+                location = stream_uri.to_string(),
+            )
+        }
+        "udp" => {
+            format!(
+                concat!(
+                    "udpsrc address={address} port={port} close-socket=false auto-multicast=true",
+                    " ! typefind name=typefinder minimum=1",
+                    " ! fakesink name=fakesink sync=false"
+                ),
+                address = stream_uri.host()?,
+                port = stream_uri.port()?,
+            )
+        }
+        unsupported => {
+            warn!("Scheme {unsupported:#?} is not supported for Redirect Pipelines");
+            return None;
+        }
+    };
 
     let pipeline = gst::parse::launch(&description)
         .expect("Failed to create pipeline")
         .downcast::<gst::Pipeline>()
         .expect("Pipeline is not a valid gst::Pipeline");
 
+    let typefinder = pipeline.by_name("typefinder")?;
+
+    let (tx, rx) = mpsc::channel(10);
+
+    typefinder.connect("have-type", false, move |values| {
+        let _typefinder = values[0].get::<gst::Element>().expect("Invalid argument");
+        let _probability = values[1].get::<u32>().expect("Invalid argument");
+        let caps = values[2].get::<gst::Caps>().expect("Invalid argument");
+
+        if let Err(error) = tx.blocking_send(caps) {
+            error!("Failed sending caps from typefinder: {error:?}");
+        }
+
+        None
+    });
+
     pipeline
         .set_state(gst::State::Playing)
         .expect("Failed to set pipeline to Playing");
 
-    let fakesink = pipeline
-        .by_name("fakesink")
-        .expect("Fakesink not found in pipeline");
-    let pad = fakesink.static_pad("sink").expect("Sink pad not found");
-
-    let encode = tokio::time::timeout(tokio::time::Duration::from_secs(15), wait_for_encode(pad))
+    let encode = tokio::time::timeout(tokio::time::Duration::from_secs(15), wait_for_encode(rx))
         .await
         .ok()
         .flatten();
@@ -147,23 +179,22 @@ pub async fn get_encode_from_rtspsrc(stream_uri: &url::Url) -> Option<VideoEncod
     encode
 }
 
-pub async fn wait_for_encode(pad: gst::Pad) -> Option<VideoEncodeType> {
-    loop {
-        if let Some(caps) = pad.current_caps() {
-            trace!("caps from rtspsrc: {caps:?}");
+pub async fn wait_for_encode(mut rx: mpsc::Receiver<gst::Caps>) -> Option<VideoEncodeType> {
+    if let Some(caps) = rx.recv().await {
+        let structure = caps.structure(0)?;
 
-            if let Some(structure) = caps.structure(0) {
-                if let Ok(encoding_name) = structure.get::<String>("encoding-name") {
-                    let encoding = match encoding_name.to_ascii_uppercase().as_str() {
-                        "H264" => Some(VideoEncodeType::H264),
-                        "H265" => Some(VideoEncodeType::H265),
-                        _unsupported => None,
-                    };
+        let encoding_name = structure.get::<String>("encoding-name").ok()?;
 
-                    break encoding;
-                }
-            }
-        }
-        tokio::time::sleep(tokio::time::Duration::from_millis(100)).await;
+        let encoding = match encoding_name.to_ascii_uppercase().as_str() {
+            "H264" => Some(VideoEncodeType::H264),
+            "H265" => Some(VideoEncodeType::H265),
+            _unsupported => None,
+        };
+
+        trace!("Found encoding {encoding:?} from caps: {caps:?}");
+
+        return encoding;
     }
+
+    return None;
 }


### PR DESCRIPTION
Since WebRTC only works with a narrow option of stream formats, we are now re-encoding the RTP packages for Redirect streams, using the same strategy as for the Onvif sources.

An example is the stream from the Swell Pro. It's a 720p H264 stream but with an RTP incompatible with WebRTC.