### PR TITLE
Ability to restart streams with REST API

### DIFF
--- a/src/lib/server/manager.rs
+++ b/src/lib/server/manager.rs
@@ -66,6 +66,7 @@ pub async fn run(server_address: &str) -> Result<(), std::io::Error> {
             .route("/info", web::get().to(pages::info))
             .route("/delete_stream", web::delete().to(pages::remove_stream))
             .route("/reset_settings", web::post().to(pages::reset_settings))
+            .route("/restart_streams", web::post().to(pages::restart_streams))
             .route("/streams", web::get().to(pages::streams))
             .route("/streams", web::post().to(pages::streams_post))
             .route("/v4l", web::get().to(pages::v4l))

--- a/src/lib/server/pages.rs
+++ b/src/lib/server/pages.rs
@@ -272,6 +272,22 @@ pub async fn reset_settings(query: web::Query<ResetSettings>) -> Result<HttpResp
 }
 
 #[api_v2_operation]
+/// Restart streams
+pub async fn restart_streams(query: web::Query<ResetSettings>) -> Result<HttpResponse> {
+    if query.all.unwrap_or_default() {
+        stream_manager::start_default()
+            .await
+            .map_err(|error| Error::Internal(format!("{error:?}")))?;
+
+        return Ok(HttpResponse::Ok().finish());
+    }
+
+    Err(Error::Internal(
+        "Missing argument for restart_streams.".to_string(),
+    ))
+}
+
+#[api_v2_operation]
 /// Provide a list of all streams configured
 pub async fn streams() -> Result<HttpResponse> {
     let streams = stream_manager::streams()


### PR DESCRIPTION
Scenario:

I'm using "Redirect" option in stream configuration, and if the source is not available during mavlink-camera-manager initialization, then signalling server and WebRTC won't be able to serve this stream when it becomes available

The config I use:
```
{
  "header": {
    "name": "Camera Manager",
    "version": 0
  },
  "mavlink_endpoint": "udpin:0.0.0.0:14550",
  "streams": [
    {
      "name": "Some RTSP stream",
      "stream_information": {
        "endpoints": [
          "rtsp://127.0.0.1:8889/stream"
        ],
        "configuration": {
          "type": "video",
          "encode": "H264",
          "height": 0,
          "width": 0,
          "frame_interval": {
            "numerator": 0,
            "denominator": 0
          }
        },
        "extended_configuration": {
          "thermal": false,
          "disable_mavlink": true
        }
      },
      "video_source": {
        "Redirect": {
          "name": "Some RTSP stream",
          "source": {
            "Redirect": "Redirect"
          }
        }
      }
    }
  ]
}
```

To get the stream running, I need to restart mavlink-camera-manager service when the source is available so the service can successfully initialize

I didn't want to add breaking changes with "healthchecking" the source in a loop, so I decided to add a simple route to the REST API that will restart all the configured streams