### PR TITLE
feature: keep config persistent after reset or restart if the stream is unavailable during restart

### DIFF
--- a/src/lib/stream/manager.rs
+++ b/src/lib/stream/manager.rs
@@ -562,7 +562,10 @@ impl Manager {
     }
 
     #[instrument(level = "debug")]
-    pub async fn remove_stream(stream_id: &webrtc::signalling_protocol::PeerId, rewrite_config: bool) -> Result<()> {
+    pub async fn remove_stream(
+        stream_id: &webrtc::signalling_protocol::PeerId,
+        rewrite_config: bool,
+    ) -> Result<()> {
         let mut manager = MANAGER.write().await;
 
         if !manager.streams.contains_key(stream_id) {


### PR DESCRIPTION
Once I added the restart_streams API I found that manager::start_default function has the next line
```
    // Gently remove all streams as we are going to replace the entire list below
    remove_all_streams().await?;
```
Which was removing the full configuration. After a restart, the config contains the streams that were available during the restart and other disappeared

`remove_all_streams` is only called from `start_default`, so I decided to resolve this simply by providing a flag, that allow or prevent the config file from modification

What do you think?