### PR TITLE
Rework streams creation

### DIFF
--- a/src/lib/mavlink/mavlink_camera_component.rs
+++ b/src/lib/mavlink/mavlink_camera_component.rs
@@ -37,7 +37,9 @@ impl MavlinkCameraComponent {
                     cfg.frame_interval.denominator as f32 / cfg.frame_interval.numerator as f32;
                 (cfg.height as u16, cfg.width as u16, framerate)
             }
-            crate::stream::types::CaptureConfiguration::Redirect(_) => (0, 0, 0.0),
+            crate::stream::types::CaptureConfiguration::Redirect(_) => {
+                unreachable!("Redirect streams now use CaptureConfiguration::Video")
+            }
         };
 
         let thermal = video_and_stream_information

--- a/src/lib/stream/mod.rs
+++ b/src/lib/stream/mod.rs
@@ -429,7 +429,7 @@ fn validate_endpoints(video_and_stream_information: &VideoAndStreamInformation) 
         .configuration
     {
         CaptureConfiguration::Video(configuration) => configuration.encode.clone(),
-        CaptureConfiguration::Redirect(_) => VideoEncodeType::Unknown("".into()),
+        CaptureConfiguration::Redirect(_) => VideoEncodeType::Unknown("Redirect stream".into()),
     };
 
     let errors: Vec<anyhow::Error> = endpoints.iter().filter_map(|endpoint| {

--- a/src/lib/stream/pipeline/fake_pipeline.rs
+++ b/src/lib/stream/pipeline/fake_pipeline.rs
@@ -1,3 +1,5 @@
+use std::sync::Arc;
+
 use anyhow::{anyhow, Result};
 use gst::prelude::*;
 use tracing::*;
@@ -24,7 +26,7 @@ pub struct FakePipeline {
 impl FakePipeline {
     #[instrument(level = "debug")]
     pub fn try_new(
-        pipeline_id: &uuid::Uuid,
+        pipeline_id: &Arc<uuid::Uuid>,
         video_and_stream_information: &VideoAndStreamInformation,
     ) -> Result<gst::Pipeline> {
         let configuration = match &video_and_stream_information

--- a/src/lib/stream/pipeline/mod.rs
+++ b/src/lib/stream/pipeline/mod.rs
@@ -6,7 +6,7 @@ pub mod runner;
 #[cfg(target_os = "linux")]
 pub mod v4l_pipeline;
 
-use std::collections::HashMap;
+use std::{collections::HashMap, sync::Arc};
 
 use anyhow::{anyhow, Context, Result};
 use enum_dispatch::enum_dispatch;
@@ -74,7 +74,7 @@ impl Pipeline {
     #[instrument(level = "debug")]
     pub fn try_new(
         video_and_stream_information: &VideoAndStreamInformation,
-        pipeline_id: &uuid::Uuid,
+        pipeline_id: &Arc<uuid::Uuid>,
     ) -> Result<Self> {
         let pipeline_state: PipelineState =
             PipelineState::try_new(video_and_stream_information, pipeline_id)?;
@@ -121,7 +121,7 @@ impl Pipeline {
 
 #[derive(Debug)]
 pub struct PipelineState {
-    pub pipeline_id: uuid::Uuid,
+    pub pipeline_id: Arc<uuid::Uuid>,
     pub pipeline: gst::Pipeline,
     pub video_tee: Option<gst::Element>,
     pub rtp_tee: Option<gst::Element>,
@@ -137,7 +137,7 @@ impl PipelineState {
     #[instrument(level = "debug")]
     pub fn try_new(
         video_and_stream_information: &VideoAndStreamInformation,
-        pipeline_id: &uuid::Uuid,
+        pipeline_id: &Arc<uuid::Uuid>,
     ) -> Result<Self> {
         let pipeline = match &video_and_stream_information.video_source {
             VideoSourceType::Gst(video) => match video.source {
@@ -177,7 +177,7 @@ impl PipelineState {
         );
 
         Ok(Self {
-            pipeline_id: *pipeline_id,
+            pipeline_id: pipeline_id.clone(),
             pipeline,
             video_tee,
             rtp_tee,
@@ -263,7 +263,7 @@ impl PipelineState {
             }
         }
 
-        self.sinks.insert(*sink_id, sink);
+        self.sinks.insert(**sink_id, sink);
 
         Ok(())
     }

--- a/src/lib/stream/pipeline/onvif_pipeline.rs
+++ b/src/lib/stream/pipeline/onvif_pipeline.rs
@@ -1,3 +1,5 @@
+use std::sync::Arc;
+
 use anyhow::{anyhow, Result};
 use gst::prelude::*;
 use tracing::*;
@@ -24,7 +26,7 @@ pub struct OnvifPipeline {
 impl OnvifPipeline {
     #[instrument(level = "debug")]
     pub fn try_new(
-        pipeline_id: &uuid::Uuid,
+        pipeline_id: &Arc<uuid::Uuid>,
         video_and_stream_information: &VideoAndStreamInformation,
     ) -> Result<gst::Pipeline> {
         match &video_and_stream_information

--- a/src/lib/stream/pipeline/qr_pipeline.rs
+++ b/src/lib/stream/pipeline/qr_pipeline.rs
@@ -1,3 +1,5 @@
+use std::sync::Arc;
+
 use anyhow::{anyhow, Result};
 use gst::prelude::*;
 use tracing::*;
@@ -24,7 +26,7 @@ pub struct QrPipeline {
 impl QrPipeline {
     #[instrument(level = "debug")]
     pub fn try_new(
-        pipeline_id: &uuid::Uuid,
+        pipeline_id: &Arc<uuid::Uuid>,
         video_and_stream_information: &VideoAndStreamInformation,
     ) -> Result<gst::Pipeline> {
         let configuration = match &video_and_stream_information

--- a/src/lib/stream/pipeline/redirect_pipeline.rs
+++ b/src/lib/stream/pipeline/redirect_pipeline.rs
@@ -1,3 +1,5 @@
+use std::sync::Arc;
+
 use anyhow::{anyhow, Context, Result};
 use gst::prelude::*;
 use tracing::*;
@@ -21,7 +23,7 @@ pub struct RedirectPipeline {
 impl RedirectPipeline {
     #[instrument(level = "debug")]
     pub fn try_new(
-        pipeline_id: &uuid::Uuid,
+        pipeline_id: &Arc<uuid::Uuid>,
         video_and_stream_information: &VideoAndStreamInformation,
     ) -> Result<gst::Pipeline> {
         match &video_and_stream_information

--- a/src/lib/stream/pipeline/v4l_pipeline.rs
+++ b/src/lib/stream/pipeline/v4l_pipeline.rs
@@ -1,3 +1,5 @@
+use std::sync::Arc;
+
 use anyhow::{anyhow, Result};
 use gst::prelude::*;
 use tracing::*;
@@ -21,7 +23,7 @@ pub struct V4lPipeline {
 impl V4lPipeline {
     #[instrument(level = "debug")]
     pub fn try_new(
-        pipeline_id: &uuid::Uuid,
+        pipeline_id: &Arc<uuid::Uuid>,
         video_and_stream_information: &VideoAndStreamInformation,
     ) -> Result<gst::Pipeline> {
         let configuration = match &video_and_stream_information

--- a/src/lib/stream/sink/webrtc_sink.rs
+++ b/src/lib/stream/sink/webrtc_sink.rs
@@ -1,3 +1,5 @@
+use std::sync::Arc;
+
 use anyhow::{anyhow, Context, Result};
 use gst::prelude::*;
 use tokio::sync::mpsc::{self, WeakUnboundedSender};
@@ -38,7 +40,7 @@ impl SinkInterface for WebRTCSink {
     fn link(
         self: &mut WebRTCSink,
         pipeline: &gst::Pipeline,
-        pipeline_id: &uuid::Uuid,
+        pipeline_id: &Arc<uuid::Uuid>,
         tee_src_pad: gst::Pad,
     ) -> Result<()> {
         // Configure transceiver https://gstreamer.freedesktop.org/documentation/webrtclib/gstwebrtc-transceiver.html?gi-language=c
@@ -100,7 +102,7 @@ impl SinkInterface for WebRTCSink {
     }
 
     #[instrument(level = "debug", skip(self, pipeline))]
-    fn unlink(&self, pipeline: &gst::Pipeline, pipeline_id: &uuid::Uuid) -> Result<()> {
+    fn unlink(&self, pipeline: &gst::Pipeline, pipeline_id: &Arc<uuid::Uuid>) -> Result<()> {
         let Some(tee_src_pad) = &self.tee_src_pad else {
             warn!("Tried to unlink Sink from a pipeline without a Tee src pad.");
             return Ok(());
@@ -113,8 +115,8 @@ impl SinkInterface for WebRTCSink {
     }
 
     #[instrument(level = "trace", skip(self))]
-    fn get_id(&self) -> uuid::Uuid {
-        self.bind.session_id
+    fn get_id(&self) -> Arc<uuid::Uuid> {
+        Arc::new(self.bind.session_id)
     }
 
     #[instrument(level = "trace", skip(self))]

--- a/src/lib/stream/types.rs
+++ b/src/lib/stream/types.rs
@@ -15,6 +15,7 @@ pub struct VideoCaptureConfiguration {
     pub frame_interval: FrameInterval,
 }
 
+#[deprecated(note = "The API will soon allow for optional CaptureConfiguration instead")]
 #[derive(Clone, Debug, Default, PartialEq, Deserialize, Serialize)]
 pub struct RedirectCaptureConfiguration {}
 
@@ -22,6 +23,7 @@ pub struct RedirectCaptureConfiguration {}
 #[serde(tag = "type", rename_all = "lowercase")]
 pub enum CaptureConfiguration {
     Video(VideoCaptureConfiguration),
+    /// This is only still used for easy stream creation, and it is always converted to Self::Video.
     Redirect(RedirectCaptureConfiguration),
 }
 

--- a/src/lib/stream/types.rs
+++ b/src/lib/stream/types.rs
@@ -44,5 +44,6 @@ pub struct StreamInformation {
 pub struct StreamStatus {
     pub id: uuid::Uuid,
     pub running: bool,
+    pub error: Option<String>,
     pub video_and_stream: VideoAndStreamInformation,
 }

--- a/src/lib/stream/webrtc/signalling_server.rs
+++ b/src/lib/stream/webrtc/signalling_server.rs
@@ -286,6 +286,11 @@ impl SignallingServer {
     pub async fn streams_information() -> Result<Vec<Stream>> {
         let streams = stream::Manager::streams_information().await?;
 
+        let streams = streams
+            .iter()
+            .filter(|stream| stream.running)
+            .collect::<Vec<_>>();
+
         Ok(streams
             .iter()
             .filter_map(|stream| {


### PR DESCRIPTION
- Closes #466 
- Closes #345

By adding a stream, the system first adds it to the manager, and then the watcher task keeps trying to actually create the stream.

The downside is that the user won't have an immediate error returning from the stream creation, and he would have to check the `running` state. To address this, an optional "error" field was added to the StreamStatus so the user can have feedback on what is going on inside the stream creation.

## In case of error:

![image](https://github.com/user-attachments/assets/aeea7b76-76a4-47da-9bb4-ce955550121c)

## In case of success:

![image](https://github.com/user-attachments/assets/eab7e730-2baf-4c90-9619-c58bbb3b3b18)
