### PR TITLE
src: lib: video: local: Reduce V4L verbosity

### DIFF
--- a/src/lib/stream/gst/utils.rs
+++ b/src/lib/stream/gst/utils.rs
@@ -131,7 +131,7 @@ pub async fn get_encode_from_stream_uri(stream_uri: &url::Url) -> Option<VideoEn
         "udp" => {
             format!(
                 concat!(
-                    "udpsrc address={address} port={port} close-socket=false auto-multicast=true",
+                    "udpsrc address={address} port={port} close-socket=false auto-multicast=true do-timestamp=true",
                     " ! typefind name=typefinder minimum=1",
                     " ! fakesink name=fakesink sync=false"
                 ),
@@ -222,7 +222,7 @@ pub async fn get_capture_configuration_from_stream_uri(
         "udp" => {
             format!(
                 concat!(
-                    "udpsrc address={address} port={port} close-socket=false auto-multicast=true",
+                    "udpsrc address={address} port={port} close-socket=false auto-multicast=true do-timestamp=true",
                 ),
                 address = stream_uri.host().context("URI without host")?,
                 port = stream_uri.port().context("URI without port")?,

--- a/src/lib/stream/mod.rs
+++ b/src/lib/stream/mod.rs
@@ -167,16 +167,21 @@ impl Stream {
                             .first()
                             .context("No URL found")?;
 
-                        let Ok(capture_configuration) =
-                            get_capture_configuration_from_stream_uri(url).await
-                        else {
-                            let error_message =
-                                "Failed getting CaptureConfiguration from endpoint, trying again soon...";
+                        let capture_configuration = match get_capture_configuration_from_stream_uri(
+                            url,
+                        )
+                        .await
+                        {
+                            Ok(capture_configuration) => capture_configuration,
+                            Err(error) => {
+                                let error_message =
+                                        format!("Failed getting CaptureConfiguration from endpoint. Error: {error:?}. Trying again soon...");
 
-                            warn!(error_message);
-                            *error_status.write().await = Err(anyhow!(error_message));
+                                warn!(error_message);
+                                *error_status.write().await = Err(anyhow!(error_message));
 
-                            continue;
+                                continue;
+                            }
                         };
 
                         *error_status.write().await = Ok(());


### PR DESCRIPTION
Every time some client requests the available streams, MCM throws all these logs:

![image](https://github.com/user-attachments/assets/13cde6be-2890-4fe3-8bd1-3a1b1109ea9a)

Since RadCam Manager is a client that requests that every second, the size of the logs is getting huge.

This PR addresses that by making those logs only available via trace.