### PR TITLE
src: lib: stream: sink: Add missing set_state to UDP and Image sinks

### DIFF
--- a/src/lib/stream/sink/image_sink.rs
+++ b/src/lib/stream/sink/image_sink.rs
@@ -106,6 +106,10 @@ impl SinkInterface for ImageSink {
         let elements = &[&self.queue, &self.proxysink];
         unlink_sink_from_tee(tee_src_pad, pipeline, elements)?;
 
+        if let Err(error) = self.pipeline.set_state(::gst::State::Null) {
+            warn!("Failed setting sink Pipeline state to Null: {error:?}");
+        }
+
         Ok(())
     }
 

--- a/src/lib/stream/sink/udp_sink.rs
+++ b/src/lib/stream/sink/udp_sink.rs
@@ -56,6 +56,10 @@ impl SinkInterface for UdpSink {
         let elements = &[&self.queue, &self.proxysink];
         unlink_sink_from_tee(tee_src_pad, pipeline, elements)?;
 
+        if let Err(error) = self.pipeline.set_state(::gst::State::Null) {
+            warn!("Failed setting sink Pipeline state to Null: {error:?}");
+        }
+
         Ok(())
     }
 


### PR DESCRIPTION
Oops, I missed this part: we need to set the state to Null of any pipeline created by the sink, otherwise, that pipeline lives forever.