### PR TITLE
.github: Update GST version for windows/macos

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -69,6 +69,8 @@ jobs:
     - name: Install gstreamer
       if: ${{ !contains(matrix.TARGET, 'linux') }}
       uses: blinemedical/setup-gstreamer@v1
+      with:
+        version: '1.26.0'
 
     - name: Install dependencies WinPcat since it's necessary for pnet crate
       # https://github.com/libpnet/libpnet/tree/v0.35.0?tab=readme-ov-file#windows


### PR DESCRIPTION
1.22.7 (the default used by the action) is no longer available, so we are moving to the latest stable release.