### PR TITLE
src: lib: Improve caps discovery by using pads strategy instead of relying on typefind

### DIFF
--- a/src/lib/controls/onvif/camera.rs
+++ b/src/lib/controls/onvif/camera.rs
@@ -243,9 +243,12 @@ impl OnvifCamera {
                 trace!("Using credentials {credentials:?}");
             }
 
-            let Some(encode) = get_encode_from_stream_uri(&stream_uri).await else {
-                warn!("Failed getting encoding from RTSP stream at {stream_uri}");
-                continue;
+            let encode = match get_encode_from_stream_uri(&stream_uri).await {
+                Ok(encode) => encode,
+                error => {
+                    warn!("Failed getting encoding from RTSP stream at {stream_uri}: {error:?}");
+                    continue;
+                }
             };
 
             let video_rate = video_encoder_configuration


### PR DESCRIPTION
The `typefind` element was not reliable enough for what we are doing / how we are using it.

The alternative is to look for the caps ourselves.

Closes #491
Closes #516