### PR TITLE
Allow disabling thumbnails and zenoh

### DIFF
--- a/src/html/index.html
+++ b/src/html/index.html
@@ -304,11 +304,13 @@
                             + ' ' + video_and_stream.stream_information.configuration.width
                             + 'x' + video_and_stream.stream_information.configuration.height
                             + ' @ ' + video_and_stream.stream_information.configuration.frame_interval.denominator
-                            + ' / ' + video_and_stream.stream_information.configuration.frame_interval.numerator + ' FPS, '
+                            + ' / ' + video_and_stream.stream_information.configuration.frame_interval.numerator + ' FPS'
                         }
                     }
-                    response += 'Thermal: ' + video_and_stream.stream_information.extended_configuration?.thermal ?? false
-                    response += 'Disable Mavlink: ' + video_and_stream.stream_information.extended_configuration?.disable_mavlink ?? false
+                    response += ', Thermal: ' + video_and_stream.stream_information.extended_configuration?.thermal ?? false
+                    response += ', Disable Mavlink: ' + video_and_stream.stream_information.extended_configuration?.disable_mavlink ?? false
+                    response += ', Disable Zenoh: ' + video_and_stream.stream_information.extended_configuration?.disable_zenoh ?? false
+                    response += ', Disable Thumbnails: ' + video_and_stream.stream_information.extended_configuration?.disable_thumbnails ?? false
                     return response
                 },
                 requestData: async function() {
@@ -395,6 +397,8 @@
                             "extended_configuration": {
                                 "thermal": Boolean(stream.extended_configuration.thermal),
                                 "disable_mavlink": Boolean(stream.extended_configuration.disable_mavlink),
+                                "disable_zenoh": Boolean(stream.extended_configuration.disable_zenoh),
+                                "disable_thumbnails": Boolean(stream.extended_configuration.disable_thumbnails),
                             },
                         }
                     }
@@ -727,6 +731,8 @@
                             this.stream.video_and_stream.stream_information.endpoints.join(", ") : ""
                         this.stream_setting.extended_configuration.thermal = Boolean(this.stream.video_and_stream.stream_information.extended_configuration?.thermal)
                         this.stream_setting.extended_configuration.disable_mavlink = Boolean(this.stream.video_and_stream.stream_information.extended_configuration?.disable_mavlink)
+                        this.stream_setting.extended_configuration.disable_zenoh = Boolean(this.stream.video_and_stream.stream_information.extended_configuration?.disable_zenoh)
+                        this.stream_setting.extended_configuration.disable_thumbnails = Boolean(this.stream.video_and_stream.stream_information.extended_configuration?.disable_thumbnails)
                     },
                     deep: true
                 },
@@ -785,6 +791,8 @@
                         extended_configuration: {
                             thermal: undefined,
                             disable_mavlink: undefined,
+                            disable_zenoh: undefined,
+                            disable_thumbnails: undefined,
                         },
                     },
                     stream_options: {
@@ -862,6 +870,20 @@
                         <input
                             type="checkbox"
                             v-model="stream_setting.extended_configuration.disable_mavlink"
+                        >
+                    </div>
+                    <div>
+                        <label>Disable Zenoh: </label>
+                        <input
+                            type="checkbox"
+                            v-model="stream_setting.extended_configuration.disable_zenoh"
+                        >
+                    </div>
+                    <div>
+                        <label>Disable Thumbnails: </label>
+                        <input
+                            type="checkbox"
+                            v-model="stream_setting.extended_configuration.disable_thumbnails"
                         >
                     </div>
 

--- a/src/lib/stream/mod.rs
+++ b/src/lib/stream/mod.rs
@@ -504,15 +504,13 @@ impl StreamState {
         }
 
         // Only create the MavlinkCamera when MAVLink is not disabled
-        if matches!(
-            video_and_stream_information
-                .stream_information
-                .extended_configuration,
-            Some(ExtendedConfiguration {
-                thermal: _,
-                disable_mavlink: false,
-            })
-        ) {
+        if video_and_stream_information
+            .stream_information
+            .extended_configuration
+            .as_ref()
+            .map(|e| !e.disable_mavlink)
+            .unwrap_or_default()
+        {
             match MavlinkCamera::try_new(&video_and_stream_information).await {
                 Ok(mavlink_camera) => {
                     stream.mavlink_camera.replace(mavlink_camera);

--- a/src/lib/stream/mod.rs
+++ b/src/lib/stream/mod.rs
@@ -443,26 +443,41 @@ impl StreamState {
         }
 
         let sink_id = Arc::new(Manager::generate_uuid(None));
-        match create_image_sink(sink_id.clone(), &video_and_stream_information) {
-            Ok(sink) => {
-                if let Some(pipeline) = stream.pipeline.as_mut() {
-                    if let Err(reason) = pipeline.add_sink(sink).await {
-                        return Err(anyhow!(
+        if !video_and_stream_information
+            .stream_information
+            .extended_configuration
+            .as_ref()
+            .map(|e| e.disable_thumbnails)
+            .unwrap_or_default()
+        {
+            match create_image_sink(sink_id.clone(), &video_and_stream_information) {
+                Ok(sink) => {
+                    if let Some(pipeline) = stream.pipeline.as_mut() {
+                        if let Err(reason) = pipeline.add_sink(sink).await {
+                            return Err(anyhow!(
                             "Failed to add Sink of type Image to the Pipeline. Reason: {reason}"
                         ));
+                        }
+                    } else {
+                        return Err(anyhow!("No Pipeline available to add Image sink"));
                     }
-                } else {
-                    return Err(anyhow!("No Pipeline available to add Image sink"));
                 }
-            }
-            Err(reason) => {
-                return Err(anyhow!(
-                    "Failed to create Sink of type Image. Reason: {reason}"
-                ));
+                Err(reason) => {
+                    return Err(anyhow!(
+                        "Failed to create Sink of type Image. Reason: {reason}"
+                    ));
+                }
             }
         }
 
-        if crate::cli::manager::enable_zenoh() {
+        if !video_and_stream_information
+            .stream_information
+            .extended_configuration
+            .as_ref()
+            .map(|e| e.disable_zenoh)
+            .unwrap_or_default()
+            && crate::cli::manager::enable_zenoh()
+        {
             let sink_id = Arc::new(Manager::generate_uuid(None));
             match create_zenoh_sink(sink_id.clone(), &video_and_stream_information).await {
                 Ok(sink) => {

--- a/src/lib/stream/types.rs
+++ b/src/lib/stream/types.rs
@@ -28,6 +28,7 @@ pub enum CaptureConfiguration {
 }
 
 #[derive(Apiv2Schema, Clone, Debug, PartialEq, Deserialize, Serialize, Default)]
+#[serde(default)]
 pub struct ExtendedConfiguration {
     pub thermal: bool,
     pub disable_mavlink: bool,

--- a/src/lib/stream/types.rs
+++ b/src/lib/stream/types.rs
@@ -31,6 +31,8 @@ pub enum CaptureConfiguration {
 pub struct ExtendedConfiguration {
     pub thermal: bool,
     pub disable_mavlink: bool,
+    pub disable_zenoh: bool,
+    pub disable_thumbnails: bool,
 }
 
 #[derive(Clone, Debug, PartialEq, Deserialize, Serialize, Apiv2Schema)]


### PR DESCRIPTION
This patch allows users to disable thumbnails (image sink) or zenoh (zenih sink) when creating each stream. The default behavior is both enable.

<img width="198" height="478" alt="image" src="https://github.com/user-attachments/assets/978696ff-239c-47f3-860b-fec8bcd4dbb4" />

Closes #518 