### PR TITLE
Update dockerfile

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -17,11 +17,6 @@ RUN apt update -y && \
         gnupg \
         htop
 
-# We need libssl.so.1.1
-# Note: if the link breaks, find it here: https://packages.ubuntu.com/focal/amd64/libssl1.1/download
-RUN wget http://security.ubuntu.com/ubuntu/pool/main/o/openssl/libssl1.1_1.1.1f-1ubuntu2.22_amd64.deb -O /tmp/openssl.deb && \
-dpkg -i /tmp/openssl.deb
-
 COPY ./target/x86_64-unknown-linux-gnu/release/mavlink-camera-manager /
 
 ENTRYPOINT ./mavlink-camera-manager --mavlink=tcpout:192.168.2.2:5777 --verbose --reset

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,4 +1,4 @@
-from ubuntu:24.04
+FROM ubuntu:24.04
 
 ARG DEBIAN_FRONTEND=noninteractive
 
@@ -19,4 +19,4 @@ RUN apt update -y && \
 
 COPY ./target/x86_64-unknown-linux-gnu/release/mavlink-camera-manager /
 
-ENTRYPOINT ./mavlink-camera-manager --mavlink=tcpout:192.168.2.2:5777 --verbose --reset
+ENTRYPOINT ["./mavlink-camera-manager", "--mavlink=tcpout:192.168.2.2:5777", "--verbose", "--reset"]


### PR DESCRIPTION
After #533, we no longer need OpenSSL as a runtime dependency :)