### PR TITLE
Move to 2024 edition

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,7 +7,7 @@ members = [
 [package]
 authors = ["Patrick José Pereira <patrickelectric@gmail.com>"]
 description = "An extensible cross-platform camera server built on top of GStreamer and Rust-MAVLink."
-edition = "2021"
+edition = "2024"
 license = "MIT"
 name = "mavlink-camera-manager"
 version = "0.2.4"

--- a/bindings/Cargo.toml
+++ b/bindings/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "bindings"
 version = "0.1.0"
-edition = "2021"
+edition = "2024"
 
 [dependencies]
 regex = { workspace = true }

--- a/src/lib/controls/onvif/camera.rs
+++ b/src/lib/controls/onvif/camera.rs
@@ -3,7 +3,7 @@ use std::sync::Arc;
 use onvif::soap;
 use onvif_schema::transport;
 
-use anyhow::{anyhow, Context, Result};
+use anyhow::{Context, Result, anyhow};
 use serde::{Deserialize, Serialize};
 use tokio::sync::RwLock;
 use tracing::*;

--- a/src/lib/controls/onvif/manager.rs
+++ b/src/lib/controls/onvif/manager.rs
@@ -5,7 +5,7 @@ use std::{
     time::Duration,
 };
 
-use anyhow::{anyhow, Context, Result};
+use anyhow::{Context, Result, anyhow};
 use futures::StreamExt as _;
 use onvif::soap::client::Credentials;
 use serde::Serialize;
@@ -205,7 +205,9 @@ impl Manager {
                                 Ok::<(), onvif::discovery::Error>(()) // Indicate success (discovery part)
                             }
                             Err(error) => {
-                                warn!("Task failed: ONVIF discovery failed on interface IP '{ip_addr}': {error:?}");
+                                warn!(
+                                    "Task failed: ONVIF discovery failed on interface IP '{ip_addr}': {error:?}"
+                                );
                                 Err(error)
                             }
                         }
@@ -222,15 +224,21 @@ impl Manager {
             for (iface_name, ip_addr, task_handle) in discovery_tasks {
                 match task_handle.await {
                     Ok(Ok(())) => {
-                        trace!("Discovery task for interface '{iface_name}' (IP: {ip_addr}) completed successfully.");
+                        trace!(
+                            "Discovery task for interface '{iface_name}' (IP: {ip_addr}) completed successfully."
+                        );
                     }
                     Ok(Err(discovery_error)) => {
                         // The task ran, but the discovery itself failed
-                        warn!("Discovery task for interface '{iface_name}' (IP: {ip_addr}) reported failure: {discovery_error:?}");
+                        warn!(
+                            "Discovery task for interface '{iface_name}' (IP: {ip_addr}) reported failure: {discovery_error:?}"
+                        );
                     }
                     Err(join_error) => {
                         // The task itself panicked or was cancelled
-                        error!("Discovery task for interface '{iface_name}' (IP: {ip_addr}) panicked or was cancelled: {join_error:?}");
+                        error!(
+                            "Discovery task for interface '{iface_name}' (IP: {ip_addr}) panicked or was cancelled: {join_error:?}"
+                        );
                     }
                 }
             }
@@ -278,9 +286,7 @@ impl Manager {
                         let ip_addr = IpAddr::V4(ipv4_network.ip());
                         trace!(
                             "Found suitable IPv4 address on interface '{}': {} (Subnet: {})",
-                            interface.name,
-                            ip_addr,
-                            ipv4_network
+                            interface.name, ip_addr, ipv4_network
                         );
                         // Return Some tuple, which will be collected and deduplicated by the HashSet
                         Some((interface.name.clone(), ip_addr))
@@ -448,7 +454,10 @@ impl Manager {
         trace!("Device credentials lookup result for UUID={device_uuid:?}: {credentials:?}");
 
         // Iterate through the device's URLs (e.g., different service endpoints)
-        trace!("Attempting to create OnvifCamera instances for device UUID={device_uuid:?}, IP={device_ip}, found {} URL(s)", device.urls.len());
+        trace!(
+            "Attempting to create OnvifCamera instances for device UUID={device_uuid:?}, IP={device_ip}, found {} URL(s)",
+            device.urls.len()
+        );
         for (index, url) in device.urls.iter().enumerate() {
             trace!(
                 "Processing URL {}/{} for device UUID={device_uuid:?}: {url}",
@@ -486,7 +495,9 @@ impl Manager {
             );
 
             let Some(streams_informations) = streams_information_option else {
-                error!("Failed getting stream information (streams_information is None) for camera created from URL: {url}");
+                error!(
+                    "Failed getting stream information (streams_information is None) for camera created from URL: {url}"
+                );
                 continue; // Move to the next URL
             };
 

--- a/src/lib/helper/develop.rs
+++ b/src/lib/helper/develop.rs
@@ -1,6 +1,6 @@
 use std::collections::HashMap;
 
-use anyhow::{anyhow, Result};
+use anyhow::{Result, anyhow};
 use thirtyfour::prelude::*;
 use tokio::{process::Command, runtime::Runtime, sync::RwLock};
 use tracing::*;
@@ -255,8 +255,8 @@ async fn task(session_cycles: i32) -> Result<()> {
             // Ignore first cycle
             if current_cycle > 0 {
                 return Err(anyhow!(
-                "Thread leak detected on cycle {current_cycle}:\n{new_tasks_since_last_cycle:#?}\n{tasks_alive_from_last_cycle:#?}"
-            ));
+                    "Thread leak detected on cycle {current_cycle}:\n{new_tasks_since_last_cycle:#?}\n{tasks_alive_from_last_cycle:#?}"
+                ));
             }
         };
 
@@ -274,8 +274,12 @@ async fn task(session_cycles: i32) -> Result<()> {
         info!("Tasks alive since last cycle: {number_of_tasks_alive_from_last_cycle}");
 
         if number_of_new_tasks_since_last_cycle > 0 || number_of_tasks_alive_from_last_cycle > 0 {
-            info!("The following tasks were created since last cycle:\n{new_tasks_since_last_cycle:#?}");
-            info!("The following tasks were alive since last cycle:\n{tasks_alive_from_last_cycle:#?}")
+            info!(
+                "The following tasks were created since last cycle:\n{new_tasks_since_last_cycle:#?}"
+            );
+            info!(
+                "The following tasks were alive since last cycle:\n{tasks_alive_from_last_cycle:#?}"
+            )
         }
     }
 

--- a/src/lib/helper/threads.rs
+++ b/src/lib/helper/threads.rs
@@ -43,9 +43,11 @@ pub fn process_tasks() -> HashMap<u32, String> {
 }
 
 pub fn start_thread_counter_thread() {
-    thread::spawn(move || loop {
-        info!("Number of child processes: {}", process_task_counter());
-        thread::sleep(Duration::from_secs(1));
+    thread::spawn(move || {
+        loop {
+            info!("Number of child processes: {}", process_task_counter());
+            thread::sleep(Duration::from_secs(1));
+        }
     });
 }
 

--- a/src/lib/logger/manager.rs
+++ b/src/lib/logger/manager.rs
@@ -8,9 +8,9 @@ use tokio::sync::broadcast::{Receiver, Sender};
 use tracing::{metadata::LevelFilter, *};
 use tracing_log::LogTracer;
 use tracing_subscriber::{
+    EnvFilter, Layer,
     fmt::{self, MakeWriter},
     layer::SubscriberExt,
-    EnvFilter, Layer,
 };
 
 use crate::cli;

--- a/src/lib/mavlink/manager.rs
+++ b/src/lib/mavlink/manager.rs
@@ -3,7 +3,7 @@ use std::{
     sync::{Arc, Mutex, RwLock},
 };
 
-use mavlink::{common::MavMessage, MavConnection, MavHeader};
+use mavlink::{MavConnection, MavHeader, common::MavMessage};
 
 use anyhow::{Context, Result};
 use tokio::sync::broadcast;
@@ -155,7 +155,9 @@ impl Manager {
                         );
                     }
                     Err(broadcast::error::RecvError::Lagged(samples)) => {
-                        warn!("Channel is lagged behind by {samples} messages. Expect degraded performance on the mavlink responsiviness.");
+                        warn!(
+                            "Channel is lagged behind by {samples} messages. Expect degraded performance on the mavlink responsiviness."
+                        );
                         continue;
                     }
                 };

--- a/src/lib/mavlink/mavlink_camera.rs
+++ b/src/lib/mavlink/mavlink_camera.rs
@@ -1,7 +1,7 @@
 use std::sync::Arc;
 
-use anyhow::{anyhow, Context, Result};
-use mavlink::{common::MavMessage, MavHeader};
+use anyhow::{Context, Result, anyhow};
+use mavlink::{MavHeader, common::MavMessage};
 use tokio::sync::broadcast;
 use tracing::*;
 use url::Url;
@@ -187,7 +187,9 @@ impl MavlinkCameraInner {
                 }
                 Ok(Message::ToBeSent(_)) => (),
                 Err(error) => {
-                    error!("Failed receiving from broadcast channel: {error:#?}. Resubscribing to the channel...");
+                    error!(
+                        "Failed receiving from broadcast channel: {error:#?}. Resubscribing to the channel..."
+                    );
 
                     receiver = receiver.resubscribe();
                 }
@@ -444,7 +446,10 @@ impl MavlinkCameraInner {
                 let result = match crate::video::video_source::reset_controls(source_string).await {
                     Ok(_) => mavlink::common::MavResult::MAV_RESULT_ACCEPTED,
                     Err(error) => {
-                        error!("Failed to reset {source_string:?} controls with its default values as {:#?}:{:#?}. Reason: {error:?}", camera.component.system_id, camera.component.component_id);
+                        error!(
+                            "Failed to reset {source_string:?} controls with its default values as {:#?}:{:#?}. Reason: {error:?}",
+                            camera.component.system_id, camera.component.component_id
+                        );
                         mavlink::common::MavResult::MAV_RESULT_DENIED
                     }
                 };
@@ -514,7 +519,10 @@ impl MavlinkCameraInner {
                     }
                     VIDEO_STREAM_INFORMATION_ID => {
                         if !validate_stream_id(camera, data.param2) {
-                            warn!("MAV_CMD_REQUEST_MESSAGE(VIDEO_STREAM_INFORMATION): unknown stream id: {:#?}.", data.param2);
+                            warn!(
+                                "MAV_CMD_REQUEST_MESSAGE(VIDEO_STREAM_INFORMATION): unknown stream id: {:#?}.",
+                                data.param2
+                            );
                             send_ack(
                                 camera,
                                 &sender,
@@ -622,7 +630,10 @@ impl MavlinkCameraInner {
         {
             Ok(_) => mavlink::common::ParamAck::PARAM_ACK_ACCEPTED,
             Err(error) => {
-                error!("Failed to set parameter {control_id:?} with value {control_value:?} for {:#?}. Reason: {error:?}", camera.component.component_id);
+                error!(
+                    "Failed to set parameter {control_id:?} with value {control_value:?} for {:#?}. Reason: {error:?}",
+                    camera.component.component_id
+                );
                 mavlink::common::ParamAck::PARAM_ACK_FAILED
             }
         };

--- a/src/lib/server/error.rs
+++ b/src/lib/server/error.rs
@@ -1,4 +1,4 @@
-use actix_web::{http::StatusCode, ResponseError};
+use actix_web::{ResponseError, http::StatusCode};
 
 use paperclip::actix::api_v2_errors;
 use validator::ValidationErrors;

--- a/src/lib/server/manager.rs
+++ b/src/lib/server/manager.rs
@@ -1,11 +1,11 @@
 use actix_cors::Cors;
 use actix_extensible_rate_limit::{
-    backend::{memory::InMemoryBackend, SimpleInputFunctionBuilder},
     RateLimiter,
+    backend::{SimpleInputFunctionBuilder, memory::InMemoryBackend},
 };
-use actix_web::{error::JsonPayloadError, App, HttpRequest, HttpServer};
+use actix_web::{App, HttpRequest, HttpServer, error::JsonPayloadError};
 use paperclip::{
-    actix::{web, OpenApiExt},
+    actix::{OpenApiExt, web},
     v2::models::{Api, Info},
 };
 use tracing::*;

--- a/src/lib/server/pages.rs
+++ b/src/lib/server/pages.rs
@@ -435,12 +435,12 @@ pub fn camera_reset_controls(json: web::Json<ResetCameraControls>) -> Result<Htt
 /// Provides a xml description file that contains information for a specific device, based on: https://mavlink.io/en/services/camera_def.html
 pub fn xml(req: HttpRequest, xml_file_request: web::Query<XmlFileRequest>) -> Result<HttpResponse> {
     let host = req.connection_info().host().to_string();
-    if let Some(ip_str) = host.split(':').next() {
-        if let Ok(ip) = ip_str.parse::<std::net::IpAddr>() {
-            if !ip.is_unspecified() && !ip.is_loopback() {
-                crate::network::utils::set_observed_address(ip_str.to_string());
-            }
-        }
+    if let Some(ip_str) = host.split(':').next()
+        && let Ok(ip) = ip_str.parse::<std::net::IpAddr>()
+        && !ip.is_unspecified()
+        && !ip.is_loopback()
+    {
+        crate::network::utils::set_observed_address(ip_str.to_string());
     }
 
     debug!("{xml_file_request:#?}");

--- a/src/lib/server/pages.rs
+++ b/src/lib/server/pages.rs
@@ -1,12 +1,12 @@
 use actix_web::{
+    HttpRequest, HttpResponse,
     http::header,
     rt,
     web::{self, Json},
-    HttpRequest, HttpResponse,
 };
 use actix_ws::Message;
 use futures::StreamExt;
-use paperclip::actix::{api_v2_operation, Apiv2Schema, CreatedJson};
+use paperclip::actix::{Apiv2Schema, CreatedJson, api_v2_operation};
 use serde::{Deserialize, Serialize};
 use serde_json::json;
 use tokio::time::Duration;
@@ -149,7 +149,7 @@ pub struct UnauthenticateOnvifDeviceRequest {
 
 use std::{ffi::OsStr, path::Path};
 
-use include_dir::{include_dir, Dir};
+use include_dir::{Dir, include_dir};
 
 static DIST: Dir<'_> = include_dir!("frontend/dist");
 

--- a/src/lib/settings/manager.rs
+++ b/src/lib/settings/manager.rs
@@ -4,7 +4,7 @@ use std::{
     sync::{Arc, RwLock},
 };
 
-use anyhow::{anyhow, Result};
+use anyhow::{Result, anyhow};
 use directories::ProjectDirs;
 use serde::{Deserialize, Serialize};
 use tracing::*;
@@ -116,7 +116,9 @@ async fn fallback_settings_with_backup_file(file_name: &str) -> SettingsStruct {
     let backup_file_name = format!("{file_name}.bak");
 
     if std::fs::metadata(file_name).is_ok() {
-        info!("The settings file {file_name:?} will be backed-up as {backup_file_name:?}, and a new (empty) settings file will be created in its place.");
+        info!(
+            "The settings file {file_name:?} will be backed-up as {backup_file_name:?}, and a new (empty) settings file will be created in its place."
+        );
 
         if let Err(error) = std::fs::copy(file_name, backup_file_name.as_str()) {
             error!("Failed to create backup file {backup_file_name:?}. Reason: {error:#?}");
@@ -145,9 +147,10 @@ async fn load_settings_from_file(file_name: &str) -> SettingsStruct {
 fn create_directories(file_name: &str) -> Result<()> {
     let path = Path::new(&file_name);
     if let Some(parent) = path.parent()
-        && let Err(error) = std::fs::create_dir_all(parent) {
-            return Err(anyhow!("Error creating directories: {error:#?}"));
-        }
+        && let Err(error) = std::fs::create_dir_all(parent)
+    {
+        return Err(anyhow!("Error creating directories: {error:#?}"));
+    }
 
     Ok(())
 }

--- a/src/lib/settings/manager.rs
+++ b/src/lib/settings/manager.rs
@@ -144,11 +144,10 @@ async fn load_settings_from_file(file_name: &str) -> SettingsStruct {
 
 fn create_directories(file_name: &str) -> Result<()> {
     let path = Path::new(&file_name);
-    if let Some(parent) = path.parent() {
-        if let Err(error) = std::fs::create_dir_all(parent) {
+    if let Some(parent) = path.parent()
+        && let Err(error) = std::fs::create_dir_all(parent) {
             return Err(anyhow!("Error creating directories: {error:#?}"));
         }
-    }
 
     Ok(())
 }

--- a/src/lib/stream/gst/utils.rs
+++ b/src/lib/stream/gst/utils.rs
@@ -1,4 +1,4 @@
-use anyhow::{anyhow, Context, Result};
+use anyhow::{Context, Result, anyhow};
 use gst::prelude::*;
 use tokio::sync::mpsc;
 use tracing::*;
@@ -110,7 +110,9 @@ pub fn check_all_plugins() -> Result<()> {
                 missing_required.push(requirement_display);
             }
             (false, false) => {
-                warn!("Optional GStreamer plugin requirement {requirement_display} is not met: Some features may not be available");
+                warn!(
+                    "Optional GStreamer plugin requirement {requirement_display} is not met: Some features may not be available"
+                );
             }
             _ => (),
         }
@@ -257,23 +259,17 @@ pub async fn wait_for_element_state_async(
 
 fn make_source_description_from_stream_uri(stream_uri: &url::Url) -> Result<String> {
     match stream_uri.scheme() {
-        "rtsp" => {
-            Ok(format!(
-                "rtspsrc name=source location={stream_uri} is-live=true latency=0 do-retransmission=false"
-            ))
-        }
-        "udp" => {
-            Ok(format!(
-                "udpsrc name=source address={address} port={port} auto-multicast=true do-timestamp=true",
-                address = stream_uri.host().context("URI without host")?,
-                port = stream_uri.port().context("URI without port")?,
-            ))
-        }
-        unsupported => {
-            Err(anyhow!(
-                "Scheme {unsupported:#?} is not supported for Redirect Pipelines"
-            ))
-        }
+        "rtsp" => Ok(format!(
+            "rtspsrc name=source location={stream_uri} is-live=true latency=0 do-retransmission=false"
+        )),
+        "udp" => Ok(format!(
+            "udpsrc name=source address={address} port={port} auto-multicast=true do-timestamp=true",
+            address = stream_uri.host().context("URI without host")?,
+            port = stream_uri.port().context("URI without port")?,
+        )),
+        unsupported => Err(anyhow!(
+            "Scheme {unsupported:#?} is not supported for Redirect Pipelines"
+        )),
     }
 }
 
@@ -498,11 +494,12 @@ fn setup_pad_and_probe(pad: &gst::Pad, tx: mpsc::Sender<gst::Caps>) -> Option<gs
 
         move |_pad, info| {
             if let Some(gst::PadProbeData::Event(ref ev)) = info.data
-                && let gst::EventView::Caps(caps_event) = ev.view() {
-                    let caps = caps_event.caps();
+                && let gst::EventView::Caps(caps_event) = ev.view()
+            {
+                let caps = caps_event.caps();
 
-                    let _ = tx.try_send(caps.to_owned());
-                }
+                let _ = tx.try_send(caps.to_owned());
+            }
             gst::PadProbeReturn::Ok
         }
     });
@@ -679,10 +676,9 @@ pub fn excise_single_element(element: &gst::Element) -> Result<()> {
             false
         }
     };
-    if null_ok
-        && let Err(error) = wait_for_element_state_sync(element, gst::State::Null, 100, 2) {
-            warn!("Excising {name}: {error}");
-        }
+    if null_ok && let Err(error) = wait_for_element_state_sync(element, gst::State::Null, 100, 2) {
+        warn!("Excising {name}: {error}");
+    }
 
     debug!("Excising {name}: done (null={null_ok}, removed={removed})");
 

--- a/src/lib/stream/gst/utils.rs
+++ b/src/lib/stream/gst/utils.rs
@@ -497,13 +497,12 @@ fn setup_pad_and_probe(pad: &gst::Pad, tx: mpsc::Sender<gst::Caps>) -> Option<gs
         let tx = tx.clone();
 
         move |_pad, info| {
-            if let Some(gst::PadProbeData::Event(ref ev)) = info.data {
-                if let gst::EventView::Caps(caps_event) = ev.view() {
+            if let Some(gst::PadProbeData::Event(ref ev)) = info.data
+                && let gst::EventView::Caps(caps_event) = ev.view() {
                     let caps = caps_event.caps();
 
                     let _ = tx.try_send(caps.to_owned());
                 }
-            }
             gst::PadProbeReturn::Ok
         }
     });
@@ -680,11 +679,10 @@ pub fn excise_single_element(element: &gst::Element) -> Result<()> {
             false
         }
     };
-    if null_ok {
-        if let Err(error) = wait_for_element_state_sync(element, gst::State::Null, 100, 2) {
+    if null_ok
+        && let Err(error) = wait_for_element_state_sync(element, gst::State::Null, 100, 2) {
             warn!("Excising {name}: {error}");
         }
-    }
 
     debug!("Excising {name}: done (null={null_ok}, removed={removed})");
 

--- a/src/lib/stream/manager.rs
+++ b/src/lib/stream/manager.rs
@@ -1,11 +1,11 @@
 use std::{collections::HashMap, sync::Arc};
 
-use anyhow::{anyhow, Context, Error, Result};
+use anyhow::{Context, Error, Result, anyhow};
 use cached::proc_macro::cached;
 use futures::stream::StreamExt;
 use gst::{
-    prelude::{ElementExtManual, GstBinExtManual},
     DebugGraphDetails,
+    prelude::{ElementExtManual, GstBinExtManual},
 };
 use tokio::sync::RwLock;
 use tracing::*;
@@ -13,7 +13,7 @@ use tracing::*;
 use crate::{
     settings,
     stream::{
-        sink::{webrtc_sink::WebRTCSink, Sink, SinkInterface},
+        sink::{Sink, SinkInterface, webrtc_sink::WebRTCSink},
         types::CaptureConfiguration,
         webrtc::signalling_protocol::BindAnswer,
     },
@@ -22,9 +22,9 @@ use crate::{
 };
 
 use super::{
+    Stream,
     types::StreamStatus,
     webrtc::{self, signalling_protocol::RTCSessionDescription},
-    Stream,
 };
 
 type ClonableResult<T> = Result<T, Arc<Error>>;
@@ -73,7 +73,12 @@ fn config_gst_plugins() {
                 name = config.name,
                 rank = config.rank,
             ),
-            Err(error) => error!("Error when trying to configure plugin {name:?} rank to {rank:?}. Reason: {error:?}", name = config.name, rank = config.rank, error=error.to_string()),
+            Err(error) => error!(
+                "Error when trying to configure plugin {name:?} rank to {rank:?}. Reason: {error:?}",
+                name = config.name,
+                rank = config.rank,
+                error = error.to_string()
+            ),
         }
     }
 }
@@ -157,12 +162,16 @@ pub async fn update_devices(
                             .then_some((idx, candidate))
                     })
                 else {
-                    error!("CRITICAL: The device was identified as {candidate_source_string:?}, but it is not the candidates list"); // This shouldn't ever be reachable, otherwise the above logic is flawed
+                    error!(
+                        "CRITICAL: The device was identified as {candidate_source_string:?}, but it is not the candidates list"
+                    ); // This shouldn't ever be reachable, otherwise the above logic is flawed
                     continue;
                 };
 
                 let VideoSourceType::Local(camera) = candidate else {
-                    error!("CRITICAL: The device was identified as {candidate_source_string:?}, but it is not a Local device"); // This shouldn't ever be reachable, otherwise the above logic is flawed
+                    error!(
+                        "CRITICAL: The device was identified as {candidate_source_string:?}, but it is not a Local device"
+                    ); // This shouldn't ever be reachable, otherwise the above logic is flawed
                     continue;
                 };
                 *source = camera.clone();
@@ -404,18 +413,20 @@ pub async fn get_jpeg_thumbnail_from_source(
                     let lifecycle_arc = lifecycle.clone();
                     std::thread::Builder::new()
                         .name("ThumbnailCooldown".into())
-                        .spawn(move || loop {
-                            std::thread::sleep(THUMBNAIL_COOLDOWN);
-                            let mut guard = cooldown_arc.lock().unwrap();
-                            match *guard {
-                                Some(last) if last.elapsed() >= THUMBNAIL_COOLDOWN => {
-                                    *guard = None;
-                                    drop(guard);
-                                    lifecycle_arc.remove_consumer(true);
-                                    break;
+                        .spawn(move || {
+                            loop {
+                                std::thread::sleep(THUMBNAIL_COOLDOWN);
+                                let mut guard = cooldown_arc.lock().unwrap();
+                                match *guard {
+                                    Some(last) if last.elapsed() >= THUMBNAIL_COOLDOWN => {
+                                        *guard = None;
+                                        drop(guard);
+                                        lifecycle_arc.remove_consumer(true);
+                                        break;
+                                    }
+                                    None => break,
+                                    _ => {}
                                 }
-                                None => break,
-                                _ => {}
                             }
                         })
                         .ok();

--- a/src/lib/stream/mod.rs
+++ b/src/lib/stream/mod.rs
@@ -296,11 +296,9 @@ impl Stream {
                         .await
                         .as_ref()
                         .is_some_and(|s| s.pipeline.is_some())
-                    {
-                        if let Some(old) = state.write().await.take() {
+                        && let Some(old) = state.write().await.take() {
                             tokio::task::spawn_blocking(move || drop(old));
                         }
-                    }
                     continue;
                 }
 
@@ -475,8 +473,8 @@ impl Stream {
                         }
                     };
 
-                    if persistent_rtsp.is_none() {
-                        if let Some(ref pipeline) = new_state.pipeline {
+                    if persistent_rtsp.is_none()
+                        && let Some(ref pipeline) = new_state.pipeline {
                             for s in pipeline.inner_state_as_ref().sinks.values() {
                                 if let sink::Sink::Rtsp(rtsp) = s {
                                     persistent_rtsp = Some(sink::rtsp_sink::RtspSinkPersistent {
@@ -488,7 +486,6 @@ impl Stream {
                                 }
                             }
                         }
-                    }
 
                     state.write().await.replace(new_state);
 
@@ -535,15 +532,14 @@ impl Stream {
                     if !is_running {
                         warn!("Pipeline {pipeline_id:?} stopped unexpectedly while Running, handling error");
                         // Mark RTSP sinks for preservation before dropping
-                        if let Some(ref old_st) = *state.read().await {
-                            if let Some(ref pipeline) = old_st.pipeline {
+                        if let Some(ref old_st) = *state.read().await
+                            && let Some(ref pipeline) = old_st.pipeline {
                                 for s in pipeline.inner_state_as_ref().sinks.values() {
                                     if let sink::Sink::Rtsp(rtsp) = s {
                                         rtsp.set_preserve_factory(true);
                                     }
                                 }
                             }
-                        }
                         let backoff = lifecycle.handle_pipeline_error();
                         warn!(
                             "Running: pipeline stopped, backoff={backoff:?}, error_count={}",
@@ -561,15 +557,14 @@ impl Stream {
                         if lifecycle.transition_to_idle() {
                             // Successfully transitioned -- tear down pipeline
                             // Mark RTSP sinks for preservation
-                            if let Some(ref old_st) = *state.read().await {
-                                if let Some(ref pipeline) = old_st.pipeline {
+                            if let Some(ref old_st) = *state.read().await
+                                && let Some(ref pipeline) = old_st.pipeline {
                                     for s in pipeline.inner_state_as_ref().sinks.values() {
                                         if let sink::Sink::Rtsp(rtsp) = s {
                                             rtsp.set_preserve_factory(true);
                                         }
                                     }
                                 }
-                            }
                             if let Some(old) = state.write().await.take() {
                                 tokio::task::spawn_blocking(move || drop(old));
                             }
@@ -889,13 +884,12 @@ impl Drop for StreamState {
                 let pipeline_weak = pipeline.downgrade();
 
                 move || {
-                    if let Some(pipeline) = pipeline_weak.upgrade() {
-                        if let Err(error) = pipeline.post_message(::gst::message::Eos::new()) {
+                    if let Some(pipeline) = pipeline_weak.upgrade()
+                        && let Err(error) = pipeline.post_message(::gst::message::Eos::new()) {
                             error!(
                                 "Failed posting Eos message into Pipeline bus. Reason: {error:?}"
                             );
                         }
-                    }
                 }
             })
             .ok();
@@ -909,11 +903,10 @@ impl Drop for StreamState {
                 let pipeline_weak = pipeline.downgrade();
 
                 move || {
-                    if let Some(pipeline) = pipeline_weak.upgrade() {
-                        if let Err(error) = pipeline.set_state(::gst::State::Null) {
+                    if let Some(pipeline) = pipeline_weak.upgrade()
+                        && let Err(error) = pipeline.set_state(::gst::State::Null) {
                             error!("Failed setting Pipeline state to Null. Reason: {error:?}");
                         }
-                    }
                 }
             });
 
@@ -937,19 +930,17 @@ impl Drop for StreamState {
             }
         }
 
-        if pipeline.current_state() != ::gst::State::Null {
-            if let Err(error) =
+        if pipeline.current_state() != ::gst::State::Null
+            && let Err(error) =
                 wait_for_element_state(pipeline.downgrade(), ::gst::State::Null, 100, 5)
             {
                 warn!("Pipeline did not reach Null state: {error:?}");
             }
-        }
 
-        if let Some(join_handle) = eos_handle {
-            if let Err(error) = join_handle.join() {
+        if let Some(join_handle) = eos_handle
+            && let Err(error) = join_handle.join() {
                 warn!("Failed joining EOS task: {error:?}");
             }
-        }
 
         // Remove all Sinks after the pipeline is stopped
         let pipeline_state = self

--- a/src/lib/stream/mod.rs
+++ b/src/lib/stream/mod.rs
@@ -14,7 +14,7 @@ use std::{
 };
 
 use ::gst::prelude::*;
-use anyhow::{anyhow, Context, Result};
+use anyhow::{Context, Result, anyhow};
 use gst::utils::get_capture_configuration_from_stream_uri;
 use manager::Manager;
 use pipeline::{Pipeline, PipelineGstreamerInterface};
@@ -28,7 +28,7 @@ use crate::{
     mavlink::mavlink_camera::MavlinkCamera,
     video::{
         types::{FrameInterval, VideoEncodeType, VideoSourceType},
-        video_source::{cameras_available, VideoSource},
+        video_source::{VideoSource, cameras_available},
     },
     video_stream::types::VideoAndStreamInformation,
 };
@@ -296,9 +296,10 @@ impl Stream {
                         .await
                         .as_ref()
                         .is_some_and(|s| s.pipeline.is_some())
-                        && let Some(old) = state.write().await.take() {
-                            tokio::task::spawn_blocking(move || drop(old));
-                        }
+                        && let Some(old) = state.write().await.take()
+                    {
+                        tokio::task::spawn_blocking(move || drop(old));
+                    }
                     continue;
                 }
 
@@ -319,7 +320,9 @@ impl Stream {
                             .await
                             .is_err()
                         {
-                            warn!("Pipeline teardown timed out in Waking handler, proceeding with pipeline creation");
+                            warn!(
+                                "Pipeline teardown timed out in Waking handler, proceeding with pipeline creation"
+                            );
                         }
                     }
 
@@ -357,7 +360,10 @@ impl Stream {
                             }
 
                             let backoff = lifecycle.handle_pipeline_error();
-                            warn!("Waking: CaptureConfiguration error, backoff={backoff:?}, error_count={}", lifecycle.error_count());
+                            warn!(
+                                "Waking: CaptureConfiguration error, backoff={backoff:?}, error_count={}",
+                                lifecycle.error_count()
+                            );
                             tokio::time::sleep(backoff).await;
                             notify.notify_one();
                             continue;
@@ -433,7 +439,10 @@ impl Stream {
                                 }
 
                                 let backoff = lifecycle.handle_pipeline_error();
-                                warn!("Waking: Local device error, backoff={backoff:?}, error_count={}", lifecycle.error_count());
+                                warn!(
+                                    "Waking: Local device error, backoff={backoff:?}, error_count={}",
+                                    lifecycle.error_count()
+                                );
                                 tokio::time::sleep(backoff).await;
                                 notify.notify_one();
                                 continue;
@@ -466,7 +475,10 @@ impl Stream {
                                 return Ok(());
                             }
                             let backoff = lifecycle.handle_pipeline_error();
-                            warn!("Waking: StreamState::try_new error, backoff={backoff:?}, error_count={}", lifecycle.error_count());
+                            warn!(
+                                "Waking: StreamState::try_new error, backoff={backoff:?}, error_count={}",
+                                lifecycle.error_count()
+                            );
                             tokio::time::sleep(backoff).await;
                             notify.notify_one();
                             continue;
@@ -474,18 +486,19 @@ impl Stream {
                     };
 
                     if persistent_rtsp.is_none()
-                        && let Some(ref pipeline) = new_state.pipeline {
-                            for s in pipeline.inner_state_as_ref().sinks.values() {
-                                if let sink::Sink::Rtsp(rtsp) = s {
-                                    persistent_rtsp = Some(sink::rtsp_sink::RtspSinkPersistent {
-                                        appsrc: Some(rtsp.rtsp_appsrc()),
-                                        pts_offset: Some(rtsp.pts_offset()),
-                                        flow_handle: Some(rtsp.flow_handle()),
-                                    });
-                                    break;
-                                }
+                        && let Some(ref pipeline) = new_state.pipeline
+                    {
+                        for s in pipeline.inner_state_as_ref().sinks.values() {
+                            if let sink::Sink::Rtsp(rtsp) = s {
+                                persistent_rtsp = Some(sink::rtsp_sink::RtspSinkPersistent {
+                                    appsrc: Some(rtsp.rtsp_appsrc()),
+                                    pts_offset: Some(rtsp.pts_offset()),
+                                    flow_handle: Some(rtsp.flow_handle()),
+                                });
+                                break;
                             }
                         }
+                    }
 
                     state.write().await.replace(new_state);
 
@@ -530,16 +543,19 @@ impl Stream {
                             .unwrap_or_default()
                     });
                     if !is_running {
-                        warn!("Pipeline {pipeline_id:?} stopped unexpectedly while Running, handling error");
+                        warn!(
+                            "Pipeline {pipeline_id:?} stopped unexpectedly while Running, handling error"
+                        );
                         // Mark RTSP sinks for preservation before dropping
                         if let Some(ref old_st) = *state.read().await
-                            && let Some(ref pipeline) = old_st.pipeline {
-                                for s in pipeline.inner_state_as_ref().sinks.values() {
-                                    if let sink::Sink::Rtsp(rtsp) = s {
-                                        rtsp.set_preserve_factory(true);
-                                    }
+                            && let Some(ref pipeline) = old_st.pipeline
+                        {
+                            for s in pipeline.inner_state_as_ref().sinks.values() {
+                                if let sink::Sink::Rtsp(rtsp) = s {
+                                    rtsp.set_preserve_factory(true);
                                 }
                             }
+                        }
                         let backoff = lifecycle.handle_pipeline_error();
                         warn!(
                             "Running: pipeline stopped, backoff={backoff:?}, error_count={}",
@@ -553,18 +569,21 @@ impl Stream {
                 Phase::Draining => {
                     let since = drain_start.get_or_insert(std::time::Instant::now());
                     if since.elapsed() >= idle_grace_period {
-                        debug!("Lazy pipeline {pipeline_id:?}: grace period expired, transitioning to Idle");
+                        debug!(
+                            "Lazy pipeline {pipeline_id:?}: grace period expired, transitioning to Idle"
+                        );
                         if lifecycle.transition_to_idle() {
                             // Successfully transitioned -- tear down pipeline
                             // Mark RTSP sinks for preservation
                             if let Some(ref old_st) = *state.read().await
-                                && let Some(ref pipeline) = old_st.pipeline {
-                                    for s in pipeline.inner_state_as_ref().sinks.values() {
-                                        if let sink::Sink::Rtsp(rtsp) = s {
-                                            rtsp.set_preserve_factory(true);
-                                        }
+                                && let Some(ref pipeline) = old_st.pipeline
+                            {
+                                for s in pipeline.inner_state_as_ref().sinks.values() {
+                                    if let sink::Sink::Rtsp(rtsp) = s {
+                                        rtsp.set_preserve_factory(true);
                                     }
                                 }
+                            }
                             if let Some(old) = state.write().await.take() {
                                 tokio::task::spawn_blocking(move || drop(old));
                             }
@@ -776,8 +795,8 @@ impl StreamState {
                     if let Some(pipeline) = stream.pipeline.as_mut() {
                         if let Err(reason) = pipeline.add_sink(sink).await {
                             return Err(anyhow!(
-                            "Failed to add Sink of type Image to the Pipeline. Reason: {reason}"
-                        ));
+                                "Failed to add Sink of type Image to the Pipeline. Reason: {reason}"
+                            ));
                         }
                     } else {
                         return Err(anyhow!("No Pipeline available to add Image sink"));
@@ -820,8 +839,8 @@ impl StreamState {
                         if let Some(pipeline) = stream.pipeline.as_mut() {
                             if let Err(reason) = pipeline.add_sink(sink).await {
                                 return Err(anyhow!(
-                                "Failed to add Sink of type Zenoh to the Pipeline. Reason: {reason}"
-                            ));
+                                    "Failed to add Sink of type Zenoh to the Pipeline. Reason: {reason}"
+                                ));
                             }
                         } else {
                             return Err(anyhow!("No Pipeline available to add Zenoh sink"));
@@ -885,11 +904,10 @@ impl Drop for StreamState {
 
                 move || {
                     if let Some(pipeline) = pipeline_weak.upgrade()
-                        && let Err(error) = pipeline.post_message(::gst::message::Eos::new()) {
-                            error!(
-                                "Failed posting Eos message into Pipeline bus. Reason: {error:?}"
-                            );
-                        }
+                        && let Err(error) = pipeline.post_message(::gst::message::Eos::new())
+                    {
+                        error!("Failed posting Eos message into Pipeline bus. Reason: {error:?}");
+                    }
                 }
             })
             .ok();
@@ -904,9 +922,10 @@ impl Drop for StreamState {
 
                 move || {
                     if let Some(pipeline) = pipeline_weak.upgrade()
-                        && let Err(error) = pipeline.set_state(::gst::State::Null) {
-                            error!("Failed setting Pipeline state to Null. Reason: {error:?}");
-                        }
+                        && let Err(error) = pipeline.set_state(::gst::State::Null)
+                    {
+                        error!("Failed setting Pipeline state to Null. Reason: {error:?}");
+                    }
                 }
             });
 
@@ -933,14 +952,15 @@ impl Drop for StreamState {
         if pipeline.current_state() != ::gst::State::Null
             && let Err(error) =
                 wait_for_element_state(pipeline.downgrade(), ::gst::State::Null, 100, 5)
-            {
-                warn!("Pipeline did not reach Null state: {error:?}");
-            }
+        {
+            warn!("Pipeline did not reach Null state: {error:?}");
+        }
 
         if let Some(join_handle) = eos_handle
-            && let Err(error) = join_handle.join() {
-                warn!("Failed joining EOS task: {error:?}");
-            }
+            && let Err(error) = join_handle.join()
+        {
+            warn!("Failed joining EOS task: {error:?}");
+        }
 
         // Remove all Sinks after the pipeline is stopped
         let pipeline_state = self

--- a/src/lib/stream/pipeline/fake_pipeline.rs
+++ b/src/lib/stream/pipeline/fake_pipeline.rs
@@ -1,6 +1,6 @@
 use std::sync::Arc;
 
-use anyhow::{anyhow, Result};
+use anyhow::{Result, anyhow};
 use gst::prelude::*;
 use tracing::*;
 
@@ -14,8 +14,8 @@ use crate::{
 };
 
 use super::{
-    PipelineGstreamerInterface, PipelineState, PIPELINE_FILTER_NAME, PIPELINE_RTP_TEE_NAME,
-    PIPELINE_VIDEO_TEE_NAME,
+    PIPELINE_FILTER_NAME, PIPELINE_RTP_TEE_NAME, PIPELINE_VIDEO_TEE_NAME,
+    PipelineGstreamerInterface, PipelineState,
 };
 
 #[derive(Debug)]
@@ -35,7 +35,7 @@ impl FakePipeline {
         {
             CaptureConfiguration::Video(configuration) => configuration,
             unsupported => {
-                return Err(anyhow!("{unsupported:?} is not supported as Fake Pipeline"))
+                return Err(anyhow!("{unsupported:?} is not supported as Fake Pipeline"));
             }
         };
 
@@ -44,7 +44,7 @@ impl FakePipeline {
             unsupported => {
                 return Err(anyhow!(
                     "VideoSourceType {unsupported:?} is not supported as Fake Pipeline"
-                ))
+                ));
             }
         };
 
@@ -53,7 +53,7 @@ impl FakePipeline {
             unsupported => {
                 return Err(anyhow!(
                     "VideoSourceGstType {unsupported:?} is not supported as Fake Pipeline"
-                ))
+                ));
             }
         };
 
@@ -84,7 +84,8 @@ impl FakePipeline {
                 let h264_encoder =
                     " ! x264enc tune=zerolatency speed-preset=ultrafast bitrate=5000";
 
-                format!(concat!(
+                format!(
+                    concat!(
                         "videotestsrc pattern={pattern} is-live=true do-timestamp=true",
                         " ! timeoverlay",
                         " ! video/x-raw,format={format}",
@@ -125,7 +126,8 @@ impl FakePipeline {
                 let h265_encoder =
                     " ! x265enc tune=zerolatency speed-preset=ultrafast bitrate=5000";
 
-                format!(concat!(
+                format!(
+                    concat!(
                         "videotestsrc pattern={pattern} is-live=true do-timestamp=true",
                         " ! timeoverlay",
                         " ! video/x-raw,format={format}",
@@ -198,7 +200,7 @@ impl FakePipeline {
             unsupported => {
                 return Err(anyhow!(
                     "Encode {unsupported:?} is not supported for Test Pipeline"
-                ))
+                ));
             }
         };
 

--- a/src/lib/stream/pipeline/mod.rs
+++ b/src/lib/stream/pipeline/mod.rs
@@ -8,7 +8,7 @@ pub mod v4l_pipeline;
 
 use std::{collections::HashMap, sync::Arc};
 
-use anyhow::{anyhow, Context, Result};
+use anyhow::{Context, Result, anyhow};
 use enum_dispatch::enum_dispatch;
 use gst::prelude::*;
 use tracing::*;
@@ -214,12 +214,13 @@ impl PipelineState {
 
         // Start the pipeline if not playing yet
         if pipeline.current_state() != gst::State::Playing
-            && let Err(error) = pipeline.set_state(gst::State::Playing) {
-                sink.unlink(pipeline, pipeline_id)?;
-                return Err(anyhow!(
-                    "Failed starting Pipeline {pipeline_id}. Reason: {error:#?}"
-                ));
-            }
+            && let Err(error) = pipeline.set_state(gst::State::Playing)
+        {
+            sink.unlink(pipeline, pipeline_id)?;
+            return Err(anyhow!(
+                "Failed starting Pipeline {pipeline_id}. Reason: {error:#?}"
+            ));
+        }
 
         if let Err(error) = wait_for_element_state_async(
             gst::prelude::ObjectExt::downgrade(pipeline),
@@ -278,9 +279,10 @@ impl PipelineState {
         // and all other sinks need it to work without freezing when dynamically
         // added.
         if !matches!(&sink, Sink::Image(..))
-            && let Err(error) = pipeline.sync_children_states() {
-                error!("Failed to syncronize children states. Reason: {error:?}");
-            }
+            && let Err(error) = pipeline.sync_children_states()
+        {
+            error!("Failed to syncronize children states. Reason: {error:?}");
+        }
 
         self.sinks.insert(**sink_id, sink);
 

--- a/src/lib/stream/pipeline/mod.rs
+++ b/src/lib/stream/pipeline/mod.rs
@@ -213,14 +213,13 @@ impl PipelineState {
         let sink_id = &sink.get_id();
 
         // Start the pipeline if not playing yet
-        if pipeline.current_state() != gst::State::Playing {
-            if let Err(error) = pipeline.set_state(gst::State::Playing) {
+        if pipeline.current_state() != gst::State::Playing
+            && let Err(error) = pipeline.set_state(gst::State::Playing) {
                 sink.unlink(pipeline, pipeline_id)?;
                 return Err(anyhow!(
                     "Failed starting Pipeline {pipeline_id}. Reason: {error:#?}"
                 ));
             }
-        }
 
         if let Err(error) = wait_for_element_state_async(
             gst::prelude::ObjectExt::downgrade(pipeline),
@@ -278,11 +277,10 @@ impl PipelineState {
         // Skipping ImageSink syncronization because it goes to some wrong state,
         // and all other sinks need it to work without freezing when dynamically
         // added.
-        if !matches!(&sink, Sink::Image(..)) {
-            if let Err(error) = pipeline.sync_children_states() {
+        if !matches!(&sink, Sink::Image(..))
+            && let Err(error) = pipeline.sync_children_states() {
                 error!("Failed to syncronize children states. Reason: {error:?}");
             }
-        }
 
         self.sinks.insert(**sink_id, sink);
 

--- a/src/lib/stream/pipeline/onvif_pipeline.rs
+++ b/src/lib/stream/pipeline/onvif_pipeline.rs
@@ -1,6 +1,6 @@
 use std::sync::Arc;
 
-use anyhow::{anyhow, Result};
+use anyhow::{Result, anyhow};
 use gst::prelude::*;
 use tracing::*;
 
@@ -14,8 +14,8 @@ use crate::{
 };
 
 use super::{
-    PipelineGstreamerInterface, PipelineState, PIPELINE_FILTER_NAME, PIPELINE_RTP_TEE_NAME,
-    PIPELINE_VIDEO_TEE_NAME,
+    PIPELINE_FILTER_NAME, PIPELINE_RTP_TEE_NAME, PIPELINE_VIDEO_TEE_NAME,
+    PipelineGstreamerInterface, PipelineState,
 };
 
 #[derive(Debug)]
@@ -37,7 +37,7 @@ impl OnvifPipeline {
             unsupported => {
                 return Err(anyhow!(
                     "{unsupported:?} is not supported as Onvif Pipeline"
-                ))
+                ));
             }
         };
 
@@ -46,7 +46,7 @@ impl OnvifPipeline {
             unsupported => {
                 return Err(anyhow!(
                     "SourceType {unsupported:?} is not supported as V4l Pipeline"
-                ))
+                ));
             }
         };
 
@@ -122,7 +122,7 @@ impl OnvifPipeline {
             unsupported => {
                 return Err(anyhow!(
                     "Encode {unsupported:?} is not supported for Onvif Pipeline"
-                ))
+                ));
             }
         };
 

--- a/src/lib/stream/pipeline/qr_pipeline.rs
+++ b/src/lib/stream/pipeline/qr_pipeline.rs
@@ -1,6 +1,6 @@
 use std::sync::Arc;
 
-use anyhow::{anyhow, Result};
+use anyhow::{Result, anyhow};
 use gst::prelude::*;
 use tracing::*;
 
@@ -14,8 +14,8 @@ use crate::{
 };
 
 use super::{
-    PipelineGstreamerInterface, PipelineState, PIPELINE_FILTER_NAME, PIPELINE_RTP_TEE_NAME,
-    PIPELINE_VIDEO_TEE_NAME,
+    PIPELINE_FILTER_NAME, PIPELINE_RTP_TEE_NAME, PIPELINE_VIDEO_TEE_NAME,
+    PipelineGstreamerInterface, PipelineState,
 };
 
 #[derive(Debug)]
@@ -37,7 +37,7 @@ impl QrPipeline {
             unsupported => {
                 return Err(anyhow!(
                     "{unsupported:?} is not supported as QrTimeStamp Pipeline"
-                ))
+                ));
             }
         };
 
@@ -46,7 +46,7 @@ impl QrPipeline {
             unsupported => {
                 return Err(anyhow!(
                     "VideoSourceType {unsupported:?} is not supported as QrTimeStamp Pipeline"
-                ))
+                ));
             }
         };
 
@@ -55,7 +55,7 @@ impl QrPipeline {
             unsupported => {
                 return Err(anyhow!(
                     "VideoSourceGstType {unsupported:?} is not supported as QrTimeStamp Pipeline"
-                ))
+                ));
             }
         };
 
@@ -65,7 +65,8 @@ impl QrPipeline {
 
         let description = match &configuration.encode {
             VideoEncodeType::H264 => {
-                format!(concat!(
+                format!(
+                    concat!(
                         "qrtimestampsrc",
                         " ! video/x-raw,width={width},height={height},framerate={interval_denominator}/{interval_numerator}",
                         " ! videoconvert",
@@ -106,7 +107,7 @@ impl QrPipeline {
             unsupported => {
                 return Err(anyhow!(
                     "Encode {unsupported:?} is not supported for Test Pipeline"
-                ))
+                ));
             }
         };
 

--- a/src/lib/stream/pipeline/redirect_pipeline.rs
+++ b/src/lib/stream/pipeline/redirect_pipeline.rs
@@ -1,6 +1,6 @@
 use std::sync::Arc;
 
-use anyhow::{anyhow, Context, Result};
+use anyhow::{Context, Result, anyhow};
 use gst::prelude::*;
 use tracing::*;
 
@@ -11,8 +11,8 @@ use crate::{
 };
 
 use super::{
-    PipelineGstreamerInterface, PipelineState, PIPELINE_FILTER_NAME, PIPELINE_RTP_TEE_NAME,
-    PIPELINE_VIDEO_TEE_NAME,
+    PIPELINE_FILTER_NAME, PIPELINE_RTP_TEE_NAME, PIPELINE_VIDEO_TEE_NAME,
+    PipelineGstreamerInterface, PipelineState,
 };
 
 #[derive(Debug)]
@@ -34,7 +34,7 @@ impl RedirectPipeline {
             unsupported => {
                 return Err(anyhow!(
                     "{unsupported:?} is not supported as Redirect Pipeline"
-                ))
+                ));
             }
         };
 
@@ -43,7 +43,7 @@ impl RedirectPipeline {
             unsupported => {
                 return Err(anyhow!(
                     "SourceType {unsupported:?} is not supported as V4l Pipeline"
-                ))
+                ));
             }
         };
 
@@ -100,7 +100,7 @@ impl RedirectPipeline {
             unsupported => {
                 return Err(anyhow!(
                     "Scheme {unsupported:#?} is not supported for Redirect Pipelines"
-                ))
+                ));
             }
         };
 
@@ -157,7 +157,7 @@ impl RedirectPipeline {
             unsupported => {
                 return Err(anyhow!(
                     "Encode {unsupported:?} is not supported for Redirect Pipeline"
-                ))
+                ));
             }
         };
 

--- a/src/lib/stream/pipeline/runner.rs
+++ b/src/lib/stream/pipeline/runner.rs
@@ -1,6 +1,6 @@
 use std::sync::Arc;
 
-use anyhow::{anyhow, Context, Result};
+use anyhow::{Context, Result, anyhow};
 use gst::prelude::*;
 use tracing::*;
 
@@ -228,11 +228,12 @@ impl PipelineRunner {
                 )?;
 
                 if pipeline.current_state() != gst::State::Playing
-                    && let Err(error) = pipeline.set_state(gst::State::Playing) {
-                        return Err(anyhow!(
-                            "Failed setting Pipeline {pipeline_name:?} to Playing state. Reason: {error:?}"
-                        ));
-                    }
+                    && let Err(error) = pipeline.set_state(gst::State::Playing)
+                {
+                    return Err(anyhow!(
+                        "Failed setting Pipeline {pipeline_name:?} to Playing state. Reason: {error:?}"
+                    ));
+                }
 
                 if let Err(error) =
                     wait_for_element_state_async(pipeline_weak.clone(), gst::State::Playing, 100, 5)
@@ -262,7 +263,9 @@ impl PipelineRunner {
                         frame_interval.numerator as f64 / frame_interval.denominator as f64,
                     )
                 } else {
-                    warn!("Invalid frame_interval {frame_interval:?}, using fallback of 1 FPS (Pipeline {pipeline_name:?})");
+                    warn!(
+                        "Invalid frame_interval {frame_interval:?}, using fallback of 1 FPS (Pipeline {pipeline_name:?})"
+                    );
                     std::time::Duration::from_secs(1)
                 }
             }
@@ -512,7 +515,9 @@ async fn bus_watcher_task(
                     let latency_ms = time.nseconds() as f64 / 1_000_000.0;
 
                     if latency_ms > 100.0 {
-                        warn!("High latency detected for Pipeline {pipeline_name:?}: {latency_ms:.2}ms - may cause noticeable delay");
+                        warn!(
+                            "High latency detected for Pipeline {pipeline_name:?}: {latency_ms:.2}ms - may cause noticeable delay"
+                        );
                     } else {
                         debug!("Current Pipeline ({pipeline_name:?}) latency: {latency_ms:.2}ms");
                     }
@@ -533,18 +538,27 @@ async fn bus_watcher_task(
                             }
                             (None, Some(new)) => {
                                 let new_ms = new.nseconds() as f64 / 1_000_000.0;
-                                debug!("Latency established for Pipeline {pipeline_name:?}: {new_ms:.2}ms"                                    );
+                                debug!(
+                                    "Latency established for Pipeline {pipeline_name:?}: {new_ms:.2}ms"
+                                );
                                 if new_ms > 100.0 {
-                                    warn!("High latency detected for Pipeline {pipeline_name:?}: {:.2}ms - may cause noticeable delay", new_ms);
+                                    warn!(
+                                        "High latency detected for Pipeline {pipeline_name:?}: {:.2}ms - may cause noticeable delay",
+                                        new_ms
+                                    );
                                 }
                             }
                             _ => {
-                                debug!("Latency recalculation completed for Pipeline {pipeline_name:?}, no change in value");
+                                debug!(
+                                    "Latency recalculation completed for Pipeline {pipeline_name:?}, no change in value"
+                                );
                             }
                         }
                     }
                     Err(error) => {
-                        warn!("Failed to recalculate latency for Pipeline {pipeline_name:?}: {error:?}");
+                        warn!(
+                            "Failed to recalculate latency for Pipeline {pipeline_name:?}: {error:?}"
+                        );
                     }
                 }
             }

--- a/src/lib/stream/pipeline/runner.rs
+++ b/src/lib/stream/pipeline/runner.rs
@@ -227,13 +227,12 @@ impl PipelineRunner {
                     "Unable to access the Pipeline ({pipeline_name:?}) from its weak reference",
                 )?;
 
-                if pipeline.current_state() != gst::State::Playing {
-                    if let Err(error) = pipeline.set_state(gst::State::Playing) {
+                if pipeline.current_state() != gst::State::Playing
+                    && let Err(error) = pipeline.set_state(gst::State::Playing) {
                         return Err(anyhow!(
                             "Failed setting Pipeline {pipeline_name:?} to Playing state. Reason: {error:?}"
                         ));
                     }
-                }
 
                 if let Err(error) =
                     wait_for_element_state_async(pipeline_weak.clone(), gst::State::Playing, 100, 5)

--- a/src/lib/stream/pipeline/v4l_pipeline.rs
+++ b/src/lib/stream/pipeline/v4l_pipeline.rs
@@ -1,6 +1,6 @@
 use std::sync::Arc;
 
-use anyhow::{anyhow, Result};
+use anyhow::{Result, anyhow};
 use gst::prelude::*;
 use tracing::*;
 
@@ -11,8 +11,8 @@ use crate::{
 };
 
 use super::{
-    PipelineGstreamerInterface, PipelineState, PIPELINE_FILTER_NAME, PIPELINE_RTP_TEE_NAME,
-    PIPELINE_VIDEO_TEE_NAME,
+    PIPELINE_FILTER_NAME, PIPELINE_RTP_TEE_NAME, PIPELINE_VIDEO_TEE_NAME,
+    PipelineGstreamerInterface, PipelineState,
 };
 
 #[derive(Debug)]
@@ -39,7 +39,7 @@ impl V4lPipeline {
             unsupported => {
                 return Err(anyhow!(
                     "SourceType {unsupported:?} is not supported as V4l Pipeline"
-                ))
+                ));
             }
         };
 
@@ -57,7 +57,7 @@ impl V4lPipeline {
                 format!(
                     concat!(
                         "v4l2src device={device} do-timestamp=true",
-                        " ! h264parse config-interval=-1",  // Here we need the parse to help the stream-format and alignment part, which is being fixated here because avc/au seems to reduce the CPU usage in the RTP payloading part.
+                        " ! h264parse config-interval=-1", // Here we need the parse to help the stream-format and alignment part, which is being fixated here because avc/au seems to reduce the CPU usage in the RTP payloading part.
                         " ! capsfilter name={filter_name} caps=video/x-h264,stream-format=avc,alignment=au,width={width},height={height},framerate={interval_denominator}/{interval_numerator}",
                         " ! tee name={video_tee_name} allow-not-linked=true",
                         " ! rtph264pay aggregate-mode=zero-latency config-interval=-1 pt=96",
@@ -136,7 +136,7 @@ impl V4lPipeline {
             unsupported => {
                 return Err(anyhow!(
                     "Encode {unsupported:?} is not supported for V4L2 Pipeline"
-                ))
+                ));
             }
         };
 

--- a/src/lib/stream/rtsp/rtsp_server.rs
+++ b/src/lib/stream/rtsp/rtsp_server.rs
@@ -4,10 +4,10 @@ use std::{
     thread,
 };
 
-use anyhow::{anyhow, Context, Result};
+use anyhow::{Context, Result, anyhow};
 use gst::prelude::*;
 use gst_rtsp::RTSPLowerTrans;
-use gst_rtsp_server::{prelude::*, RTSPTransportMode};
+use gst_rtsp_server::{RTSPTransportMode, prelude::*};
 use tracing::*;
 
 use crate::stream::sink::rtsp_sink::RtspFlowHandle;
@@ -194,7 +194,7 @@ impl RTSPServer {
             unsupported => {
                 return Err(anyhow!(
                     "Video caps {unsupported:?} not supported for RTSP Sink"
-                ))
+                ));
             }
         };
 
@@ -253,7 +253,9 @@ impl RTSPServer {
             .path_to_factory
             .insert(path.to_string(), factory)
         {
-            return Err(anyhow!("Error: required path already exists! The older was updated with the new configurations: {server:#?}"));
+            return Err(anyhow!(
+                "Error: required path already exists! The older was updated with the new configurations: {server:#?}"
+            ));
         }
 
         Ok(())

--- a/src/lib/stream/sink/image_sink.rs
+++ b/src/lib/stream/sink/image_sink.rs
@@ -3,7 +3,7 @@ use std::{
     sync::{Arc, Mutex},
 };
 
-use anyhow::{anyhow, Error, Result};
+use anyhow::{Error, Result, anyhow};
 use gst::prelude::*;
 use tracing::*;
 
@@ -15,7 +15,7 @@ use crate::{
     video_stream::types::VideoAndStreamInformation,
 };
 
-use super::{link_sink_to_tee, unlink_sink_from_tee, SinkInterface};
+use super::{SinkInterface, link_sink_to_tee, unlink_sink_from_tee};
 
 type ClonableResult<T> = Result<T, Arc<Error>>;
 
@@ -39,9 +39,10 @@ struct CachedThumbnails {
 impl CachedThumbnails {
     pub fn try_get(&self, settings: &ThumbnailSettings) -> Result<Option<Vec<u8>>> {
         if let Some(thumbnail) = self.map.get(settings)
-            && std::time::Instant::now() - thumbnail.instant < std::time::Duration::from_secs(1) {
-                return Ok(Some(thumbnail.image.to_vec()));
-            }
+            && std::time::Instant::now() - thumbnail.instant < std::time::Duration::from_secs(1)
+        {
+            return Ok(Some(thumbnail.image.to_vec()));
+        }
 
         Ok(None)
     }
@@ -166,15 +167,17 @@ impl SinkInterface for ImageSink {
             .name("EOS".to_string())
             .spawn(move || {
                 if let Some(pipeline) = pipeline_weak.upgrade()
-                    && let Err(error) = pipeline.post_message(gst::message::Eos::new()) {
-                        error!("Failed posting Eos message into Sink bus. Reason: {error:?}");
-                    }
+                    && let Err(error) = pipeline.post_message(gst::message::Eos::new())
+                {
+                    error!("Failed posting Eos message into Sink bus. Reason: {error:?}");
+                }
                 if let Some(pipeline) = encode_pipeline_weak.upgrade()
-                    && let Err(error) = pipeline.post_message(gst::message::Eos::new()) {
-                        error!(
-                            "Failed posting Eos message into encode pipeline bus. Reason: {error:?}"
-                        );
-                    }
+                    && let Err(error) = pipeline.post_message(gst::message::Eos::new())
+                {
+                    error!(
+                        "Failed posting Eos message into encode pipeline bus. Reason: {error:?}"
+                    );
+                }
             })
             .expect("Failed spawning EOS thread")
             .join()
@@ -230,7 +233,9 @@ impl ImageSink {
                         element.set_property("max-size-time", 0u64);
                     }
                     None => {
-                        warn!("Failed to customize proxysrc's queue: Failed to find queue in proxysrc");
+                        warn!(
+                            "Failed to customize proxysrc's queue: Failed to find queue in proxysrc"
+                        );
                     }
                 }
             }
@@ -279,9 +284,9 @@ impl ImageSink {
             VideoEncodeType::H265 => {
                 // For h265, we need to filter-out unwanted non-key frames here, before decoding it.
                 let filter = gst::ElementFactory::make("identity")
-                .property("drop-buffer-flags", gst::BufferFlags::DELTA_UNIT)
-                .property("sync", false)
-                .build()?;
+                    .property("drop-buffer-flags", gst::BufferFlags::DELTA_UNIT)
+                    .property("sync", false)
+                    .build()?;
                 let decoder = gst::ElementFactory::make("avdec_h265").build()?;
                 try_set_property(&decoder, "lowres", 2); // (0) is 'full'; (1) is '1/2-size'; (2) is '1/4-size'
                 try_set_property(&decoder, "skip-frame", 32); // (0) is 'default'; (8) is 'non-ref'; (16) is 'bidir'; (24) is 'non-intra'; (32) is 'non-key'; (48) is 'all'
@@ -306,7 +311,7 @@ impl ImageSink {
             _ => {
                 return Err(anyhow!(
                     "Unsupported video encoding for ImageSink: {encoding:?}. The supported are: H264, H265, MJPG, RGB and YUYV"
-                ))
+                ));
             }
         };
 
@@ -532,9 +537,10 @@ impl ImageSink {
 
         // Unblock the queue's src pad to allow data to flow to the decoder
         if let Some(blocker) = self.pad_blocker.lock().unwrap().take()
-            && let Some(queue_src_pad) = self.queue.static_pad("src") {
-                queue_src_pad.remove_probe(blocker);
-            }
+            && let Some(queue_src_pad) = self.queue.static_pad("src")
+        {
+            queue_src_pad.remove_probe(blocker);
+        }
 
         // Request an immediate keyframe from the upstream encoder so the
         // decoder can produce a frame without waiting for the next natural

--- a/src/lib/stream/sink/image_sink.rs
+++ b/src/lib/stream/sink/image_sink.rs
@@ -38,11 +38,10 @@ struct CachedThumbnails {
 
 impl CachedThumbnails {
     pub fn try_get(&self, settings: &ThumbnailSettings) -> Result<Option<Vec<u8>>> {
-        if let Some(thumbnail) = self.map.get(settings) {
-            if std::time::Instant::now() - thumbnail.instant < std::time::Duration::from_secs(1) {
+        if let Some(thumbnail) = self.map.get(settings)
+            && std::time::Instant::now() - thumbnail.instant < std::time::Duration::from_secs(1) {
                 return Ok(Some(thumbnail.image.to_vec()));
             }
-        }
 
         Ok(None)
     }
@@ -166,18 +165,16 @@ impl SinkInterface for ImageSink {
         if let Err(error) = std::thread::Builder::new()
             .name("EOS".to_string())
             .spawn(move || {
-                if let Some(pipeline) = pipeline_weak.upgrade() {
-                    if let Err(error) = pipeline.post_message(gst::message::Eos::new()) {
+                if let Some(pipeline) = pipeline_weak.upgrade()
+                    && let Err(error) = pipeline.post_message(gst::message::Eos::new()) {
                         error!("Failed posting Eos message into Sink bus. Reason: {error:?}");
                     }
-                }
-                if let Some(pipeline) = encode_pipeline_weak.upgrade() {
-                    if let Err(error) = pipeline.post_message(gst::message::Eos::new()) {
+                if let Some(pipeline) = encode_pipeline_weak.upgrade()
+                    && let Err(error) = pipeline.post_message(gst::message::Eos::new()) {
                         error!(
                             "Failed posting Eos message into encode pipeline bus. Reason: {error:?}"
                         );
                     }
-                }
             })
             .expect("Failed spawning EOS thread")
             .join()
@@ -534,11 +531,10 @@ impl ImageSink {
         let mut receiver = self.flat_samples_sender.subscribe();
 
         // Unblock the queue's src pad to allow data to flow to the decoder
-        if let Some(blocker) = self.pad_blocker.lock().unwrap().take() {
-            if let Some(queue_src_pad) = self.queue.static_pad("src") {
+        if let Some(blocker) = self.pad_blocker.lock().unwrap().take()
+            && let Some(queue_src_pad) = self.queue.static_pad("src") {
                 queue_src_pad.remove_probe(blocker);
             }
-        }
 
         // Request an immediate keyframe from the upstream encoder so the
         // decoder can produce a frame without waiting for the next natural

--- a/src/lib/stream/sink/mod.rs
+++ b/src/lib/stream/sink/mod.rs
@@ -273,9 +273,10 @@ pub fn unlink_sink_from_tee(
         // (normally the queue's sink pad, but may be the webrtcbin's sink pad if
         // the queue was excised at runtime).
         if let Some(peer_pad) = tee_src_pad.peer()
-            && let Err(unlink_err) = tee_src_pad.unlink(&peer_pad) {
-                warn!("Failed unlinking tee src pad from peer: {unlink_err:?}");
-            }
+            && let Err(unlink_err) = tee_src_pad.unlink(&peer_pad)
+        {
+            warn!("Failed unlinking tee src pad from peer: {unlink_err:?}");
+        }
 
         if let Some(parent) = tee_src_pad.parent_element() {
             parent.release_request_pad(tee_src_pad)

--- a/src/lib/stream/sink/mod.rs
+++ b/src/lib/stream/sink/mod.rs
@@ -272,11 +272,10 @@ pub fn unlink_sink_from_tee(
         // Unlink the tee src pad from whatever downstream pad it is connected to
         // (normally the queue's sink pad, but may be the webrtcbin's sink pad if
         // the queue was excised at runtime).
-        if let Some(peer_pad) = tee_src_pad.peer() {
-            if let Err(unlink_err) = tee_src_pad.unlink(&peer_pad) {
+        if let Some(peer_pad) = tee_src_pad.peer()
+            && let Err(unlink_err) = tee_src_pad.unlink(&peer_pad) {
                 warn!("Failed unlinking tee src pad from peer: {unlink_err:?}");
             }
-        }
 
         if let Some(parent) = tee_src_pad.parent_element() {
             parent.release_request_pad(tee_src_pad)

--- a/src/lib/stream/sink/rtsp_sink.rs
+++ b/src/lib/stream/sink/rtsp_sink.rs
@@ -1,9 +1,9 @@
 use std::sync::{
-    atomic::{AtomicBool, AtomicUsize, Ordering},
     Arc, Mutex,
+    atomic::{AtomicBool, AtomicUsize, Ordering},
 };
 
-use anyhow::{anyhow, Context, Result};
+use anyhow::{Context, Result, anyhow};
 use gst::prelude::*;
 use tracing::*;
 
@@ -11,7 +11,7 @@ use crate::stream::{
     gst::utils::try_set_property, lifecycle::LifecycleState, rtsp::rtsp_scheme::RTSPScheme,
 };
 
-use super::{link_sink_to_tee, unlink_sink_from_tee, SinkInterface};
+use super::{SinkInterface, link_sink_to_tee, unlink_sink_from_tee};
 
 pub type SharedAppSrc = Arc<Mutex<Option<gst_app::AppSrc>>>;
 pub type SharedPtsOffset = Arc<Mutex<Option<gst::ClockTime>>>;

--- a/src/lib/stream/sink/udp_sink.rs
+++ b/src/lib/stream/sink/udp_sink.rs
@@ -46,8 +46,8 @@ impl SinkInterface for UdpSink {
         let elements = &[&self.proxysink];
         link_sink_to_tee(tee_src_pad, pipeline, elements)?;
 
-        if let Some(queue) = &self.proxysrc_queue {
-            if let Some(src_pad) = queue.static_pad("src") {
+        if let Some(queue) = &self.proxysrc_queue
+            && let Some(src_pad) = queue.static_pad("src") {
                 let queue_weak = queue.downgrade();
                 src_pad.add_probe(
                     gst::PadProbeType::BUFFER | gst::PadProbeType::BUFFER_LIST,
@@ -57,7 +57,6 @@ impl SinkInterface for UdpSink {
                     },
                 );
             }
-        }
 
         Ok(())
     }

--- a/src/lib/stream/sink/udp_sink.rs
+++ b/src/lib/stream/sink/udp_sink.rs
@@ -1,6 +1,6 @@
 use std::sync::Arc;
 
-use anyhow::{anyhow, Context, Result};
+use anyhow::{Context, Result, anyhow};
 use gst::prelude::*;
 use tracing::*;
 
@@ -9,7 +9,7 @@ use crate::{
     video_stream::types::VideoAndStreamInformation,
 };
 
-use super::{link_sink_to_tee, unlink_sink_from_tee, SinkInterface};
+use super::{SinkInterface, link_sink_to_tee, unlink_sink_from_tee};
 
 #[derive(Debug)]
 pub struct UdpSink {
@@ -47,16 +47,17 @@ impl SinkInterface for UdpSink {
         link_sink_to_tee(tee_src_pad, pipeline, elements)?;
 
         if let Some(queue) = &self.proxysrc_queue
-            && let Some(src_pad) = queue.static_pad("src") {
-                let queue_weak = queue.downgrade();
-                src_pad.add_probe(
-                    gst::PadProbeType::BUFFER | gst::PadProbeType::BUFFER_LIST,
-                    move |_pad, _info| {
-                        excise_proxysrc_queue(&queue_weak);
-                        gst::PadProbeReturn::Remove
-                    },
-                );
-            }
+            && let Some(src_pad) = queue.static_pad("src")
+        {
+            let queue_weak = queue.downgrade();
+            src_pad.add_probe(
+                gst::PadProbeType::BUFFER | gst::PadProbeType::BUFFER_LIST,
+                move |_pad, _info| {
+                    excise_proxysrc_queue(&queue_weak);
+                    gst::PadProbeReturn::Remove
+                },
+            );
+        }
 
         Ok(())
     }

--- a/src/lib/stream/sink/webrtc_sink.rs
+++ b/src/lib/stream/sink/webrtc_sink.rs
@@ -1,6 +1,6 @@
 use std::sync::Arc;
 
-use anyhow::{anyhow, Context, Result};
+use anyhow::{Context, Result, anyhow};
 use gst::prelude::*;
 use tokio::sync::mpsc::{self, WeakUnboundedSender};
 use tracing::*;
@@ -17,7 +17,7 @@ use crate::{
     },
 };
 
-use super::{force_sync_false_on_element, link_sink_to_tee, unlink_sink_from_tee, SinkInterface};
+use super::{SinkInterface, force_sync_false_on_element, link_sink_to_tee, unlink_sink_from_tee};
 
 const PLAYOUT_DELAY_URI: &str = "http://www.webrtc.org/experiments/rtp-hdrext/playout-delay";
 const PLAYOUT_DELAY_EXT_ID: u8 = 13;
@@ -544,9 +544,10 @@ impl WebRTCBinInterface for WebRTCSinkWeakProxy {
             };
 
             if let Some(webrtcbin) = webrtcbin_weak.upgrade()
-                && let Err(error) = this.on_offer_created(&webrtcbin, &offer) {
-                    error!("Failed to send SDP offer: {error}");
-                }
+                && let Err(error) = this.on_offer_created(&webrtcbin, &offer)
+            {
+                error!("Failed to send SDP offer: {error}");
+            }
         });
 
         webrtcbin.emit_by_name::<()>("create-offer", &[&None::<gst::Structure>, &promise]);
@@ -733,12 +734,12 @@ impl WebRTCBinInterface for WebRTCSinkWeakProxy {
         // This avoids a negotiation loop when the browser doesn't accept the SDP we sent
         if let Some(remote_sdp) = remote_sdp
             && gst_webrtc::WebRTCSDPType::Answer == remote_sdp.type_()
-                && remote_sdp.type_() == sdp.type_()
-            {
-                debug!("Skipping SDP because this session already has an SDP answer");
+            && remote_sdp.type_() == sdp.type_()
+        {
+            debug!("Skipping SDP because this session already has an SDP answer");
 
-                return Ok(());
-            }
+            return Ok(());
+        }
 
         let sdp = gst_webrtc::WebRTCSessionDescription::new(sdp.type_(), sanitize_sdp(sdp.sdp())?);
 
@@ -949,13 +950,15 @@ fn strip_fec_and_red_from_media(media: &mut gst_sdp::SDPMediaRef) {
 
     for attr in media.attributes() {
         if attr.key() == "rtpmap"
-            && let Some(value) = attr.value() {
-                let lower = value.to_lowercase();
-                if (lower.contains(" red/") || lower.contains(" ulpfec/"))
-                    && let Some(pt) = value.split_whitespace().next() {
-                        fec_red_pts.push(pt.to_string());
-                    }
+            && let Some(value) = attr.value()
+        {
+            let lower = value.to_lowercase();
+            if (lower.contains(" red/") || lower.contains(" ulpfec/"))
+                && let Some(pt) = value.split_whitespace().next()
+            {
+                fec_red_pts.push(pt.to_string());
             }
+        }
     }
 
     if fec_red_pts.is_empty() {
@@ -968,10 +971,11 @@ fn strip_fec_and_red_from_media(media: &mut gst_sdp::SDPMediaRef) {
     for (idx, attr) in media.attributes().enumerate() {
         if matches!(attr.key(), "rtpmap" | "fmtp")
             && let Some(value) = attr.value()
-                && let Some(pt) = value.split_whitespace().next()
-                    && fec_red_pts.iter().any(|p| p == pt) {
-                        attr_indices.push(idx);
-                    }
+            && let Some(pt) = value.split_whitespace().next()
+            && fec_red_pts.iter().any(|p| p == pt)
+        {
+            attr_indices.push(idx);
+        }
     }
     for idx in attr_indices.into_iter().rev() {
         let _ = media.remove_attribute(idx as u32);
@@ -980,9 +984,10 @@ fn strip_fec_and_red_from_media(media: &mut gst_sdp::SDPMediaRef) {
     let mut fmt_indices: Vec<u32> = Vec::new();
     for i in 0..media.formats_len() {
         if let Some(fmt) = media.format(i)
-            && fec_red_pts.iter().any(|p| p == fmt) {
-                fmt_indices.push(i);
-            }
+            && fec_red_pts.iter().any(|p| p == fmt)
+        {
+            fmt_indices.push(i);
+        }
     }
     for idx in fmt_indices.into_iter().rev() {
         let _ = media.remove_format(idx);
@@ -1077,9 +1082,10 @@ fn optimise_send_path(webrtcbin: &gst::Element, queue: &gst::Element) {
     });
 
     if crate::cli::manager::is_dot_enabled()
-        && let Some(bin) = webrtcbin.downcast_ref::<gst::Bin>() {
-            crate::stream::gst::utils::dump_bin_elements(bin, "WebRTCBin internals");
-        }
+        && let Some(bin) = webrtcbin.downcast_ref::<gst::Bin>()
+    {
+        crate::stream::gst::utils::dump_bin_elements(bin, "WebRTCBin internals");
+    }
 }
 
 /// Send a ForceKeyUnit event upstream so the encoder produces a fresh keyframe

--- a/src/lib/stream/sink/webrtc_sink.rs
+++ b/src/lib/stream/sink/webrtc_sink.rs
@@ -543,11 +543,10 @@ impl WebRTCBinInterface for WebRTCSinkWeakProxy {
                 }
             };
 
-            if let Some(webrtcbin) = webrtcbin_weak.upgrade() {
-                if let Err(error) = this.on_offer_created(&webrtcbin, &offer) {
+            if let Some(webrtcbin) = webrtcbin_weak.upgrade()
+                && let Err(error) = this.on_offer_created(&webrtcbin, &offer) {
                     error!("Failed to send SDP offer: {error}");
                 }
-            }
         });
 
         webrtcbin.emit_by_name::<()>("create-offer", &[&None::<gst::Structure>, &promise]);
@@ -732,15 +731,14 @@ impl WebRTCBinInterface for WebRTCSinkWeakProxy {
         };
 
         // This avoids a negotiation loop when the browser doesn't accept the SDP we sent
-        if let Some(remote_sdp) = remote_sdp {
-            if gst_webrtc::WebRTCSDPType::Answer == remote_sdp.type_()
+        if let Some(remote_sdp) = remote_sdp
+            && gst_webrtc::WebRTCSDPType::Answer == remote_sdp.type_()
                 && remote_sdp.type_() == sdp.type_()
             {
                 debug!("Skipping SDP because this session already has an SDP answer");
 
                 return Ok(());
             }
-        }
 
         let sdp = gst_webrtc::WebRTCSessionDescription::new(sdp.type_(), sanitize_sdp(sdp.sdp())?);
 
@@ -950,16 +948,14 @@ fn strip_fec_and_red_from_media(media: &mut gst_sdp::SDPMediaRef) {
     let mut fec_red_pts: Vec<String> = Vec::new();
 
     for attr in media.attributes() {
-        if attr.key() == "rtpmap" {
-            if let Some(value) = attr.value() {
+        if attr.key() == "rtpmap"
+            && let Some(value) = attr.value() {
                 let lower = value.to_lowercase();
-                if lower.contains(" red/") || lower.contains(" ulpfec/") {
-                    if let Some(pt) = value.split_whitespace().next() {
+                if (lower.contains(" red/") || lower.contains(" ulpfec/"))
+                    && let Some(pt) = value.split_whitespace().next() {
                         fec_red_pts.push(pt.to_string());
                     }
-                }
             }
-        }
     }
 
     if fec_red_pts.is_empty() {
@@ -970,15 +966,12 @@ fn strip_fec_and_red_from_media(media: &mut gst_sdp::SDPMediaRef) {
 
     let mut attr_indices: Vec<usize> = Vec::new();
     for (idx, attr) in media.attributes().enumerate() {
-        if matches!(attr.key(), "rtpmap" | "fmtp") {
-            if let Some(value) = attr.value() {
-                if let Some(pt) = value.split_whitespace().next() {
-                    if fec_red_pts.iter().any(|p| p == pt) {
+        if matches!(attr.key(), "rtpmap" | "fmtp")
+            && let Some(value) = attr.value()
+                && let Some(pt) = value.split_whitespace().next()
+                    && fec_red_pts.iter().any(|p| p == pt) {
                         attr_indices.push(idx);
                     }
-                }
-            }
-        }
     }
     for idx in attr_indices.into_iter().rev() {
         let _ = media.remove_attribute(idx as u32);
@@ -986,11 +979,10 @@ fn strip_fec_and_red_from_media(media: &mut gst_sdp::SDPMediaRef) {
 
     let mut fmt_indices: Vec<u32> = Vec::new();
     for i in 0..media.formats_len() {
-        if let Some(fmt) = media.format(i) {
-            if fec_red_pts.iter().any(|p| p == fmt) {
+        if let Some(fmt) = media.format(i)
+            && fec_red_pts.iter().any(|p| p == fmt) {
                 fmt_indices.push(i);
             }
-        }
     }
     for idx in fmt_indices.into_iter().rev() {
         let _ = media.remove_format(idx);
@@ -1084,11 +1076,10 @@ fn optimise_send_path(webrtcbin: &gst::Element, queue: &gst::Element) {
         gst::PadProbeReturn::Remove
     });
 
-    if crate::cli::manager::is_dot_enabled() {
-        if let Some(bin) = webrtcbin.downcast_ref::<gst::Bin>() {
+    if crate::cli::manager::is_dot_enabled()
+        && let Some(bin) = webrtcbin.downcast_ref::<gst::Bin>() {
             crate::stream::gst::utils::dump_bin_elements(bin, "WebRTCBin internals");
         }
-    }
 }
 
 /// Send a ForceKeyUnit event upstream so the encoder produces a fresh keyframe

--- a/src/lib/stream/sink/zenoh_sink.rs
+++ b/src/lib/stream/sink/zenoh_sink.rs
@@ -1,6 +1,6 @@
 use std::sync::Arc;
 
-use anyhow::{anyhow, Context, Result};
+use anyhow::{Context, Result, anyhow};
 use gst::prelude::*;
 use tokio::task::JoinHandle;
 use tracing::*;
@@ -16,8 +16,8 @@ use crate::{
 };
 
 use super::{
-    link_sink_to_tee, types::zenoh_message::CompressedVideo, types::zenoh_message::Timestamp,
-    unlink_sink_from_tee, SinkInterface,
+    SinkInterface, link_sink_to_tee, types::zenoh_message::CompressedVideo,
+    types::zenoh_message::Timestamp, unlink_sink_from_tee,
 };
 
 #[derive(Debug)]
@@ -64,16 +64,17 @@ impl SinkInterface for ZenohSink {
         link_sink_to_tee(tee_src_pad, pipeline, elements)?;
 
         if let Some(queue) = &self.proxysrc_queue
-            && let Some(src_pad) = queue.static_pad("src") {
-                let queue_weak = queue.downgrade();
-                src_pad.add_probe(
-                    gst::PadProbeType::BUFFER | gst::PadProbeType::BUFFER_LIST,
-                    move |_pad, _info| {
-                        excise_proxysrc_queue(&queue_weak);
-                        gst::PadProbeReturn::Remove
-                    },
-                );
-            }
+            && let Some(src_pad) = queue.static_pad("src")
+        {
+            let queue_weak = queue.downgrade();
+            src_pad.add_probe(
+                gst::PadProbeType::BUFFER | gst::PadProbeType::BUFFER_LIST,
+                move |_pad, _info| {
+                    excise_proxysrc_queue(&queue_weak);
+                    gst::PadProbeReturn::Remove
+                },
+            );
+        }
 
         Ok(())
     }
@@ -205,7 +206,7 @@ impl ZenohSink {
             _ => {
                 return Err(anyhow!(
                     "Unsupported video encoding for ZenohSink: {video_encoding:?}. The supported are: H264 and H265"
-                ))
+                ));
             }
         }
 

--- a/src/lib/stream/sink/zenoh_sink.rs
+++ b/src/lib/stream/sink/zenoh_sink.rs
@@ -63,8 +63,8 @@ impl SinkInterface for ZenohSink {
         let elements = &[&self.proxysink];
         link_sink_to_tee(tee_src_pad, pipeline, elements)?;
 
-        if let Some(queue) = &self.proxysrc_queue {
-            if let Some(src_pad) = queue.static_pad("src") {
+        if let Some(queue) = &self.proxysrc_queue
+            && let Some(src_pad) = queue.static_pad("src") {
                 let queue_weak = queue.downgrade();
                 src_pad.add_probe(
                     gst::PadProbeType::BUFFER | gst::PadProbeType::BUFFER_LIST,
@@ -74,7 +74,6 @@ impl SinkInterface for ZenohSink {
                     },
                 );
             }
-        }
 
         Ok(())
     }

--- a/src/lib/stream/webrtc/signalling_server.rs
+++ b/src/lib/stream/webrtc/signalling_server.rs
@@ -342,13 +342,12 @@ impl SignallingServer {
             },
         };
 
-        if let Some(answer) = answer {
-            if let Err(reason) = sender.send(Ok(Message::from(answer))) {
+        if let Some(answer) = answer
+            && let Err(reason) = sender.send(Ok(Message::from(answer))) {
                 return Err(anyhow!(
                     "Failed sending message to mpsc channel. Reason: {reason:}"
                 ));
             }
-        }
 
         Ok(())
     }

--- a/src/lib/stream/webrtc/signalling_server.rs
+++ b/src/lib/stream/webrtc/signalling_server.rs
@@ -3,8 +3,8 @@ use std::{
     sync::{Arc, Mutex},
 };
 
-use anyhow::{anyhow, Context, Result};
-use async_tungstenite::{tokio::TokioAdapter, tungstenite, WebSocketStream};
+use anyhow::{Context, Result, anyhow};
+use async_tungstenite::{WebSocketStream, tokio::TokioAdapter, tungstenite};
 use futures::{SinkExt, StreamExt};
 use tokio::{
     net::{TcpListener, TcpStream},
@@ -343,11 +343,12 @@ impl SignallingServer {
         };
 
         if let Some(answer) = answer
-            && let Err(reason) = sender.send(Ok(Message::from(answer))) {
-                return Err(anyhow!(
-                    "Failed sending message to mpsc channel. Reason: {reason:}"
-                ));
-            }
+            && let Err(reason) = sender.send(Ok(Message::from(answer)))
+        {
+            return Err(anyhow!(
+                "Failed sending message to mpsc channel. Reason: {reason:}"
+            ));
+        }
 
         Ok(())
     }

--- a/src/lib/stream/webrtc/turn_server.rs
+++ b/src/lib/stream/webrtc/turn_server.rs
@@ -9,10 +9,10 @@ use anyhow::{Context, Result};
 use tokio::net::UdpSocket;
 use tracing::*;
 use turn::{
+    Error,
     auth::*,
     relay::relay_static::*,
     server::{config::*, *},
-    Error,
 };
 use webrtc_util::vnet::net::Net;
 

--- a/src/lib/video/local/video_source_local_linux.rs
+++ b/src/lib/video/local/video_source_local_linux.rs
@@ -2,7 +2,7 @@ use std::cmp::max;
 use std::collections::HashMap;
 use std::sync::{Arc, Mutex};
 
-use anyhow::{anyhow, Result};
+use anyhow::{Result, anyhow};
 use lazy_static::lazy_static;
 use paperclip::actix::Apiv2Schema;
 use regex::Regex;
@@ -77,7 +77,9 @@ impl VideoSourceLocalType {
             return result;
         }
 
-        let msg = format!("Unable to identify the local camera connection type, please report the problem: {description:?}");
+        let msg = format!(
+            "Unable to identify the local camera connection type, please report the problem: {description:?}"
+        );
         if description == "platform:bcm2835-isp" {
             // Filter out the log for this particular device, because regarding to Raspberry Pis, it will always be there and we will never use it.
             trace!(msg);
@@ -184,7 +186,9 @@ impl VideoSourceLocal {
         // Then in the next reboot, `Alpha` changed to port B, and `Beta` was changed to port A, then it's
         // impossible to differentiate them using only the name.
         trace!("Outcome n.5!");
-        warn!("There is more than one camera with the same name and encode, which means that their identification/configurations could have been swaped");
+        warn!(
+            "There is more than one camera with the same name and encode, which means that their identification/configurations could have been swaped"
+        );
         Ok(None)
     }
 
@@ -454,7 +458,9 @@ impl VideoSourceFormats for VideoSourceLocal {
             // To prevent it, we are currently constraining it
             // to a max. of 1920 x 1080 px, and a max. 30 FPS.
             if matches!(typ, VideoSourceLocalType::LegacyRpiCam(_)) {
-                warn!("To support Raspiberry Pi Cameras in Legacy Camera Mode without bugs, resolution is constrained to 1920 x 1080 @ 30 FPS.");
+                warn!(
+                    "To support Raspiberry Pi Cameras in Legacy Camera Mode without bugs, resolution is constrained to 1920 x 1080 @ 30 FPS."
+                );
                 let max_width = 1920;
                 let max_height = 1080;
                 let max_fps = 30;
@@ -1144,12 +1150,14 @@ mod device_identification_tests {
                 unreachable!("Wrong setup")
             };
 
-            assert!(source
-                .to_owned()
-                .try_identify_device(capture_configuration, &candidates)
-                .await
-                .expect("Failed to identify the only device with the same name and encode")
-                .is_none())
+            assert!(
+                source
+                    .to_owned()
+                    .try_identify_device(capture_configuration, &candidates)
+                    .await
+                    .expect("Failed to identify the only device with the same name and encode")
+                    .is_none()
+            )
         }
 
         VIDEO_FORMATS.lock().unwrap().clear();

--- a/src/lib/video/video_source_gst.rs
+++ b/src/lib/video/video_source_gst.rs
@@ -3,7 +3,7 @@ use serde::{Deserialize, Serialize};
 
 use crate::{
     controls::types::Control,
-    stream::gst::utils::{is_gst_plugin_available, PluginRequirement},
+    stream::gst::utils::{PluginRequirement, is_gst_plugin_available},
 };
 
 use super::{

--- a/src/lib/video/xml.rs
+++ b/src/lib/video/xml.rs
@@ -1,4 +1,4 @@
-use anyhow::{anyhow, Result};
+use anyhow::{Result, anyhow};
 use serde::Serialize;
 
 use crate::controls::types::ControlType;

--- a/src/lib/video_stream/types.rs
+++ b/src/lib/video_stream/types.rs
@@ -1,6 +1,6 @@
 use std::collections::HashSet;
 
-use anyhow::{anyhow, Result};
+use anyhow::{Result, anyhow};
 use paperclip::actix::Apiv2Schema;
 use serde::{Deserialize, Serialize};
 

--- a/src/lib/zenoh/mod.rs
+++ b/src/lib/zenoh/mod.rs
@@ -1,7 +1,7 @@
-use anyhow::{anyhow, Result};
+use anyhow::{Result, anyhow};
 use tokio::sync::OnceCell;
 use tracing::*;
-use zenoh::{config::ZenohId, Config, Session};
+use zenoh::{Config, Session, config::ZenohId};
 
 static SESSION: OnceCell<Session> = OnceCell::const_new();
 


### PR DESCRIPTION
This PR:
* Changes the edition to 2024
* Apply changes from `cargo fmt`.
* Apply changes from `cargo clippy --fix`.

Why? I need a feature from the 2024 edition related to the borrow-checker for async.

Note: I ran `cargo fix --edition`, but all warnings were false alarms.