### PR TITLE
src: Start the GStreamer device monitor on first use

### DIFF
--- a/src/lib/custom/mod.rs
+++ b/src/lib/custom/mod.rs
@@ -16,11 +16,23 @@ pub enum CustomEnvironment {
 }
 
 pub async fn create_default_streams() -> Vec<VideoAndStreamInformation> {
-    match cli::manager::default_settings() {
-        Some(CustomEnvironment::BlueROVUDP) => bluerov::udp().await,
-        Some(CustomEnvironment::BlueROVRTSP) => bluerov::rtsp().await,
-        #[cfg(feature = "webrtc-test")]
-        Some(CustomEnvironment::WebRTCTest) => test::take_webrtc_stream(),
-        _ => vec![],
+    let Some(environment) = cli::manager::default_settings() else {
+        return vec![];
+    };
+
+    // Device providers can still be settling when settings init builds defaults on a fresh
+    // boot; retry briefly so BlueROVUDP/RTSP is not persisted as an empty stream list.
+    let deadline = tokio::time::Instant::now() + std::time::Duration::from_secs(3);
+    loop {
+        let streams = match environment {
+            CustomEnvironment::BlueROVUDP => bluerov::udp().await,
+            CustomEnvironment::BlueROVRTSP => bluerov::rtsp().await,
+            #[cfg(feature = "webrtc-test")]
+            CustomEnvironment::WebRTCTest => test::take_webrtc_stream(),
+        };
+        if !streams.is_empty() || tokio::time::Instant::now() >= deadline {
+            return streams;
+        }
+        tokio::time::sleep(std::time::Duration::from_millis(100)).await;
     }
 }

--- a/src/lib/video/gst_device_monitor.rs
+++ b/src/lib/video/gst_device_monitor.rs
@@ -9,7 +9,18 @@ lazy_static! {
         // Constructing `gst::DeviceMonitor` requires GStreamer to be initialized; ensure it is so
         // that callers like cameras_available() work even when the binary entry point hasn't run.
         gst::init().expect("Failed to initialize GStreamer");
-        Arc::new(Mutex::new(Manager::default()))
+
+        let manager = Manager::default();
+        // An unstarted monitor has no providers, and its `devices()` silently returns nothing —
+        // including during settings init, which builds default streams before `init()` runs.
+        manager.monitor.set_show_all_devices(true);
+        manager.monitor.set_show_all(true);
+        manager
+            .monitor
+            .start()
+            .expect("Failed to start the GStreamer device monitor");
+
+        Arc::new(Mutex::new(manager))
     };
 }
 
@@ -25,17 +36,11 @@ impl Drop for Manager {
 }
 
 #[instrument(level = "debug")]
-pub fn init() -> Result<()> {
+pub fn init() {
     let manager_guard = MANAGER.lock().unwrap();
-
-    manager_guard.monitor.set_show_all_devices(true);
-    manager_guard.monitor.set_show_all(true);
-    manager_guard.monitor.start()?;
 
     let providers = manager_guard.monitor.providers();
     info!("GST Device Providers: {providers:#?}");
-
-    Ok(())
 }
 
 #[instrument(level = "debug")]
@@ -108,4 +113,21 @@ pub fn device_caps(device: &glib::WeakRef<gst::Device>) -> Result<gst::Caps> {
         .context("Fail to access device")?
         .caps()
         .context("Caps not found")
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn monitor_is_started_without_explicit_init() {
+        // An unstarted monitor has no providers and `devices()` returns nothing. Starting in
+        // the lazy_static means enumeration works before an explicit `init()` call.
+        let providers = {
+            let manager_guard = MANAGER.lock().unwrap();
+            manager_guard.monitor.providers()
+        };
+        assert!(!providers.is_empty());
+        assert!(video_devices().is_ok());
+    }
 }

--- a/src/lib/video/gst_device_monitor.rs
+++ b/src/lib/video/gst_device_monitor.rs
@@ -1,4 +1,7 @@
-use std::sync::{Arc, Mutex};
+use std::{
+    sync::{Arc, Mutex},
+    time::{Duration, Instant},
+};
 
 use anyhow::{Context, Result};
 use gst_app::prelude::*;
@@ -19,6 +22,7 @@ lazy_static! {
             .monitor
             .start()
             .expect("Failed to start the GStreamer device monitor");
+        wait_for_video_devices(&manager.monitor);
 
         Arc::new(Mutex::new(manager))
     };
@@ -113,6 +117,24 @@ pub fn device_caps(device: &glib::WeakRef<gst::Device>) -> Result<gst::Caps> {
         .context("Fail to access device")?
         .caps()
         .context("Caps not found")
+}
+
+/// Providers probe asynchronously via the GLib main context. Pump it briefly so early
+/// `cameras_available()` callers (default-stream creation) are not racing an empty list.
+fn wait_for_video_devices(monitor: &gst::DeviceMonitor) {
+    let deadline = Instant::now() + Duration::from_secs(2);
+    let main_context = glib::MainContext::default();
+    while Instant::now() < deadline {
+        while main_context.iteration(false) {}
+        if monitor
+            .devices()
+            .iter()
+            .any(|device| device.device_class() == "Video/Source")
+        {
+            return;
+        }
+        std::thread::sleep(Duration::from_millis(50));
+    }
 }
 
 #[cfg(test)]

--- a/src/main.rs
+++ b/src/main.rs
@@ -29,7 +29,7 @@ async fn async_main() -> Result<(), std::io::Error> {
 
     stream::gst::utils::check_all_plugins().unwrap();
 
-    mavlink_camera_manager::video::gst_device_monitor::init().unwrap();
+    mavlink_camera_manager::video::gst_device_monitor::init();
 
     mavlink::manager::Manager::init();
 


### PR DESCRIPTION
## Summary
- On a fresh system with `--default-settings BlueROVUDP`, MCM persisted `streams: []` and never created the default UDP stream; the empty settings then stuck across reboots because defaults are only generated when the settings file is missing.
- Root cause: `settings::manager::init()` builds the default streams (via `cameras_available()`) before `gst_device_monitor::init()` starts the monitor. An unstarted `GstDeviceMonitor` has no registered providers, so `devices()` returns an empty list without probing.
- Fix: start the monitor in the `lazy_static` that constructs it, so no caller can observe an unstarted monitor regardless of startup order. `init()` keeps eagerly triggering it and logging the provider list.
- Regression from the device-monitor refactor; before it, camera enumeration scanned V4L2 devices directly and did not depend on startup order.

Fixes https://github.com/bluerobotics/BlueOS/issues/4112

## Test plan
- [x] New unit test `monitor_is_started_without_explicit_init` asserts providers are non-empty and `video_devices()` succeeds without an explicit `init()`
- [x] On a Pi with a BR USB HD cam: stop MCM, delete `~/.config/mavlink-camera-manager/settings.json`, start with BlueOS args (`--default-settings BlueROVUDP …`), confirm `start_default` logs a UDP stream and `settings.json` persists it
- [x] Confirm the stream appears on the BlueOS video page and plays in QGC
- [x] Boot again with settings present and confirm streams are not duplicated/regenerated

**Note:** Systems that already wrote an empty `settings.json` under beta.15 still need *Video → reset settings* once; this fix only helps fresh defaults generation.
