### PR TITLE
.github: workflows: Install apt deps without broken package cache

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -70,9 +70,9 @@ jobs:
           path: frontend
 
       - name: Install build dependencies
-        uses: awalsh128/cache-apt-pkgs-action@v1
-        with:
-          packages: |
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y --no-install-recommends \
             libunwind-dev \
             libclang-dev \
             pkg-config \
@@ -110,9 +110,9 @@ jobs:
         run: cargo clippy --all-features --locked
 
       - name: Install runtime dependencies
-        uses: awalsh128/cache-apt-pkgs-action@v1
-        with:
-          packages: |
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y --no-install-recommends \
             gstreamer1.0-tools \
             gstreamer1.0-x \
             gstreamer1.0-nice \


### PR DESCRIPTION
## Summary
- The `test` job fails on current PRs because `awalsh128/cache-apt-pkgs-action` restores a corrupt empty cache (~12KB), reports `Restoring 0 packages from cache`, and never installs `libglib2.0-dev` / GStreamer headers.
- Clippy then dies with `The system library glib-2.0 required by crate glib-sys was not found`.
- Replace the apt cache action with plain `apt-get install` for build and runtime deps.

Unrelated flake also seen on PRs: linux-desktop checkout `server certificate verification failed` — not addressed here.

## Test plan
- [ ] CI `test` job on this PR installs packages and gets past clippy/`glib-sys`
- [ ] CI `test` job runs `cargo test`
