### PR TITLE
.github: workflows: apt-get update before cache-apt-pkgs-action

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -69,6 +69,9 @@ jobs:
           name: frontend-dist
           path: frontend
 
+      - name: Refresh apt package lists
+        run: sudo apt-get update
+
       - name: Install build dependencies
         uses: awalsh128/cache-apt-pkgs-action@v1
         with:
@@ -108,6 +111,9 @@ jobs:
 
       - name: Check clippy
         run: cargo clippy --all-features --locked
+
+      - name: Refresh apt package lists
+        run: sudo apt-get update
 
       - name: Install runtime dependencies
         uses: awalsh128/cache-apt-pkgs-action@v1


### PR DESCRIPTION
## Summary
- `awalsh128/cache-apt-pkgs-action` only refreshes apt lists when `ACT=true` (nektos/act). On GitHub-hosted runners it skips `apt-get update`.
- Stale indices then cause apt 404s; the action sources `lib.sh` with `set +e`, so the failure is ignored and an empty ~12KB cache is saved under `cache-apt-pkgs_*`.
- Later jobs restore that poison (`Restoring 0 packages`) and clippy fails looking for `glib-2.0`.
- Fix: run `sudo apt-get update` before each `cache-apt-pkgs-action` use. Keep the cache action.

Verified green on fork: https://github.com/joaoantoniocardoso/mavlink-camera-manager/actions/runs/31561843602 (cold install wrote a ~411MB apt cache).

## Test plan
- [x] Upstream `test` job refreshes apt, installs packages (or restores a non-empty cache), and passes clippy/`cargo test`
- [x] No new ~12KB `cache-apt-pkgs_*` entries after a cache miss
