### PR TITLE
src: lib: mavlink: Honor broadcast target IDs of 0

### DIFF
--- a/src/lib/mavlink/mavlink_camera.rs
+++ b/src/lib/mavlink/mavlink_camera.rs
@@ -267,9 +267,12 @@ impl MavlinkCameraInner {
             }
         }
 
-        if data.target_system != camera.component.system_id
-            || data.target_component != camera.component.component_id
-        {
+        if !is_addressed_to(
+            data.target_system,
+            data.target_component,
+            camera.component.system_id,
+            camera.component.component_id,
+        ) {
             trace!("Ignoring {data:?}, wrong command id or system id");
             return;
         }
@@ -667,9 +670,12 @@ impl MavlinkCameraInner {
             }
         }
 
-        if data.target_system != camera.component.system_id
-            || data.target_component != camera.component.component_id
-        {
+        if !is_addressed_to(
+            data.target_system,
+            data.target_component,
+            camera.component.system_id,
+            camera.component.component_id,
+        ) {
             trace!("Ignoring {data:?}, wrong command id or system id");
             return;
         }
@@ -709,9 +715,12 @@ impl MavlinkCameraInner {
         header: &MavHeader,
         data: &mavlink::common::PARAM_EXT_REQUEST_READ_DATA,
     ) {
-        if data.target_system != camera.component.system_id
-            || data.target_component != camera.component.component_id
-        {
+        if !is_addressed_to(
+            data.target_system,
+            data.target_component,
+            camera.component.system_id,
+            camera.component.component_id,
+        ) {
             trace!("Ignoring {data:?}, wrong command id or system id");
             return;
         }
@@ -760,9 +769,12 @@ impl MavlinkCameraInner {
     ) {
         let our_header = camera.component.header();
 
-        if data.target_system != our_header.system_id
-            || data.target_component != our_header.component_id
-        {
+        if !is_addressed_to(
+            data.target_system,
+            data.target_component,
+            our_header.system_id,
+            our_header.component_id,
+        ) {
             trace!("Ignoring {data:?}, wrong command id or system id");
             return;
         }

--- a/src/lib/mavlink/utils.rs
+++ b/src/lib/mavlink/utils.rs
@@ -120,3 +120,36 @@ pub fn control_id_from_param_id<const N: usize>(param_id: &[u8; N]) -> Option<u6
 
     id_string.parse().ok()
 }
+
+/// Returns true if this component should handle a message with the given target address.
+///
+/// `target_system` 0 broadcasts to all systems. `target_component` 0 is `MAV_COMP_ID_ALL`.
+pub fn is_addressed_to(
+    target_system: u8,
+    target_component: u8,
+    our_system_id: u8,
+    our_component_id: u8,
+) -> bool {
+    let system_matches = target_system == 0 || target_system == our_system_id;
+    let component_matches = target_component
+        == mavlink::common::MavComponent::MAV_COMP_ID_ALL as u8
+        || target_component == our_component_id;
+    system_matches && component_matches
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn is_addressed_to_honors_broadcast_zero() {
+        assert!(is_addressed_to(1, 106, 1, 106));
+        assert!(is_addressed_to(1, 0, 1, 106));
+        assert!(is_addressed_to(0, 106, 1, 106));
+        assert!(is_addressed_to(0, 0, 1, 106));
+        assert!(!is_addressed_to(1, 107, 1, 106));
+        assert!(!is_addressed_to(2, 106, 1, 106));
+        assert!(!is_addressed_to(2, 0, 1, 106));
+        assert!(!is_addressed_to(0, 107, 1, 106));
+    }
+}


### PR DESCRIPTION
## Summary
- Accept `COMMAND_LONG` and `PARAM_EXT_*` messages whose `target_component` is `0` (`MAV_COMP_ID_ALL`) or whose `target_system` is `0` (broadcast to all systems).
- Previously MCM required an exact match on both IDs, so a GCS could not command all cameras with the standard MAVLink broadcast address.

## Test plan
- [x] Unit test `is_addressed_to_honors_broadcast_zero` covers exact, broadcast, and mismatch cases.
- [x] Send `COMMAND_LONG` with `target_component = 0` and this camera's `target_system`; confirm the camera handles it (e.g. `MAV_CMD_REQUEST_CAMERA_INFORMATION` is ACKed).
- [x] Send `COMMAND_LONG` with a different non-zero `target_component`; confirm it is still ignored.
- [x] With two cameras, send `target_component = 0` and confirm both respond.
