### PR TITLE
cargo: Update sysinfo crate, drop unused features

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4435,6 +4435,25 @@ dependencies = [
 ]
 
 [[package]]
+name = "objc2-core-foundation"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2a180dd8642fa45cdb7dd721cd4c11b1cadd4929ce112ebd8b9f5803cc79d536"
+dependencies = [
+ "bitflags 2.10.0",
+]
+
+[[package]]
+name = "objc2-io-kit"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "33fafba39597d6dc1fb709123dfa8289d39406734be322956a69f0931c73bb15"
+dependencies = [
+ "libc",
+ "objc2-core-foundation",
+]
+
+[[package]]
 name = "oid-registry"
 version = "0.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5266,26 +5285,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "99d9a13982dcf210057a8a78572b2217b667c3beacbf3a0d8b454f6f82837d38"
 dependencies = [
  "getrandom 0.3.4",
-]
-
-[[package]]
-name = "rayon"
-version = "1.11.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "368f01d005bf8fd9b1206fb6fa653e6c4a81ceb1466406b81792d87c5677a58f"
-dependencies = [
- "either",
- "rayon-core",
-]
-
-[[package]]
-name = "rayon-core"
-version = "1.13.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "22e18b0f0062d30d4230b2e85ff77fdfe4326feb054b9783a3460d8435c8ab91"
-dependencies = [
- "crossbeam-deque",
- "crossbeam-utils",
 ]
 
 [[package]]
@@ -6468,17 +6467,16 @@ dependencies = [
 
 [[package]]
 name = "sysinfo"
-version = "0.29.11"
+version = "0.39.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cd727fc423c2060f6c92d9534cef765c65a6ed3f428a03d7def74a8c4348e666"
+checksum = "d2071df9448915b71c4fe6d25deaf1c22f12bd234f01540b77312bb8e41361e6"
 dependencies = [
- "cfg-if",
- "core-foundation-sys",
  "libc",
+ "memchr",
  "ntapi",
- "once_cell",
- "rayon",
- "winapi",
+ "objc2-core-foundation",
+ "objc2-io-kit",
+ "windows 0.62.2",
 ]
 
 [[package]]
@@ -7850,11 +7848,23 @@ version = "0.61.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9babd3a767a4c1aef6900409f85f5d53ce2544ccdfaa86dad48c91782c6d6893"
 dependencies = [
- "windows-collections",
+ "windows-collections 0.2.0",
  "windows-core 0.61.2",
- "windows-future",
+ "windows-future 0.2.1",
  "windows-link 0.1.3",
- "windows-numerics",
+ "windows-numerics 0.2.0",
+]
+
+[[package]]
+name = "windows"
+version = "0.62.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "527fadee13e0c05939a6a05d5bd6eec6cd2e3dbd648b9f8e447c6518133d8580"
+dependencies = [
+ "windows-collections 0.3.2",
+ "windows-core 0.62.2",
+ "windows-future 0.3.2",
+ "windows-numerics 0.3.1",
 ]
 
 [[package]]
@@ -7864,6 +7874,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3beeceb5e5cfd9eb1d76b381630e82c4241ccd0d27f1a39ed41b2760b255c5e8"
 dependencies = [
  "windows-core 0.61.2",
+]
+
+[[package]]
+name = "windows-collections"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "23b2d95af1a8a14a3c7367e1ed4fc9c20e0a26e79551b1454d72583c97cc6610"
+dependencies = [
+ "windows-core 0.62.2",
 ]
 
 [[package]]
@@ -7900,7 +7919,18 @@ checksum = "fc6a41e98427b19fe4b73c550f060b59fa592d7d686537eebf9385621bfbad8e"
 dependencies = [
  "windows-core 0.61.2",
  "windows-link 0.1.3",
- "windows-threading",
+ "windows-threading 0.1.0",
+]
+
+[[package]]
+name = "windows-future"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e1d6f90251fe18a279739e78025bd6ddc52a7e22f921070ccdc67dde84c605cb"
+dependencies = [
+ "windows-core 0.62.2",
+ "windows-link 0.2.1",
+ "windows-threading 0.2.1",
 ]
 
 [[package]]
@@ -7945,6 +7975,16 @@ checksum = "9150af68066c4c5c07ddc0ce30421554771e528bde427614c61038bc2c92c2b1"
 dependencies = [
  "windows-core 0.61.2",
  "windows-link 0.1.3",
+]
+
+[[package]]
+name = "windows-numerics"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6e2e40844ac143cdb44aead537bbf727de9b044e107a0f1220392177d15b0f26"
+dependencies = [
+ "windows-core 0.62.2",
+ "windows-link 0.2.1",
 ]
 
 [[package]]
@@ -8107,6 +8147,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b66463ad2e0ea3bbf808b7f1d371311c80e115c0b71d60efc142cafbcfb057a6"
 dependencies = [
  "windows-link 0.1.3",
+]
+
+[[package]]
+name = "windows-threading"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3949bd5b99cafdf1c7ca86b43ca564028dfe27d66958f2470940f73d86d75b37"
+dependencies = [
+ "windows-link 0.2.1",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -62,7 +62,7 @@ validator = { version = "0.16", features = ["derive"] }
 thiserror = "2.0"
 
 ## FINAL
-sysinfo = "0.29"
+sysinfo = { version = "0.39", default-features = false, features = ["system", "disk"] }
 chrono = "0.4"
 lazy_static = "1.4.0"
 include_dir = "0.7.3"

--- a/src/lib/helper/threads.rs
+++ b/src/lib/helper/threads.rs
@@ -1,18 +1,22 @@
 use std::{collections::HashMap, thread, time::Duration};
 
 use cached::proc_macro::cached;
-use sysinfo::{PidExt, ProcessExt, System, SystemExt};
+use sysinfo::{ProcessRefreshKind, ProcessesToUpdate, System};
 use tracing::*;
 
 #[cached(time = 1)]
 pub fn process_task_counter() -> usize {
-    let mut system = System::new_all();
+    let mut system = System::new();
     let pid = sysinfo::get_current_pid().expect("Failed to get current PID.");
-    system.refresh_process(pid);
+    refresh_tasks_of(&mut system, &[pid]);
 
     #[cfg(target_os = "linux")]
     {
-        system.process(pid).unwrap().tasks.len()
+        system
+            .process(pid)
+            .unwrap()
+            .tasks()
+            .map_or(0, |tasks| tasks.len())
     }
 
     #[cfg(not(target_os = "linux"))]
@@ -23,16 +27,30 @@ pub fn process_task_counter() -> usize {
 
 #[cached(time = 1)]
 pub fn process_tasks() -> HashMap<u32, String> {
-    let mut system = System::new_all();
+    let mut system = System::new();
     let pid = sysinfo::get_current_pid().expect("Failed to get current PID.");
-    system.refresh_process(pid);
+    refresh_tasks_of(&mut system, &[pid]);
 
     #[cfg(target_os = "linux")]
     {
-        let tasks = &system.process(pid).unwrap().tasks;
+        let Some(tasks) = system
+            .process(pid)
+            .unwrap()
+            .tasks()
+            .map(|tasks| tasks.iter().copied().collect::<Vec<_>>())
+        else {
+            return HashMap::new();
+        };
+
+        // Task names are only populated by refreshing each task as a process.
+        refresh_tasks_of(&mut system, &tasks);
+
         tasks
             .iter()
-            .map(|(pid, process)| (pid.as_u32(), process.name().to_string()))
+            .filter_map(|task| {
+                let process = system.process(*task)?;
+                Some((task.as_u32(), process.name().to_string_lossy().to_string()))
+            })
             .collect()
     }
 
@@ -40,6 +58,16 @@ pub fn process_tasks() -> HashMap<u32, String> {
     {
         HashMap::new()
     }
+}
+
+/// Refreshes only the given processes: refreshing all of them (as
+/// `System::new_all` does) costs milliseconds of `/proc` walking per call.
+fn refresh_tasks_of(system: &mut System, pids: &[sysinfo::Pid]) {
+    system.refresh_processes_specifics(
+        ProcessesToUpdate::Some(pids),
+        false,
+        ProcessRefreshKind::nothing(),
+    );
 }
 
 pub fn start_thread_counter_thread() {

--- a/src/lib/mavlink/sys_info.rs
+++ b/src/lib/mavlink/sys_info.rs
@@ -1,4 +1,4 @@
-use sysinfo::{DiskExt, System, SystemExt};
+use sysinfo::{DiskRefreshKind, Disks, System};
 use tracing::*;
 
 #[derive(Debug)]
@@ -15,11 +15,9 @@ pub fn sys_info() -> SysInfo {
     let mut local_total_capacity = 0;
     let mut local_available_capacity = 0;
 
-    let mut system = System::new_all();
-    system.refresh_disks();
+    let disks = Disks::new_with_refreshed_list_specifics(DiskRefreshKind::nothing().with_storage());
 
-    let main_disk = system
-        .disks()
+    let main_disk = disks
         .iter()
         .find(|disk| disk.mount_point().as_os_str() == "/");
     match main_disk {
@@ -33,7 +31,7 @@ pub fn sys_info() -> SysInfo {
         }
     }
 
-    let boottime_ms = system.boot_time() * 1000;
+    let boottime_ms = System::boot_time() * 1000;
 
     SysInfo {
         time_boot_ms: boottime_ms as u32,


### PR DESCRIPTION
CPU use of MCM was higher than expected with the new 4K Cam Manager because of this sys_info code.

Why the difference only _now_? 4kCam's new health diagnosis feature calls the info endpoint.