### PR TITLE
src: lib: logger: Add GStreamer version

### DIFF
--- a/src/lib/logger/manager.rs
+++ b/src/lib/logger/manager.rs
@@ -197,6 +197,7 @@ pub fn init() {
         option_env!("VERGEN_GIT_SHA").unwrap_or("?"),
         env!("VERGEN_BUILD_TIMESTAMP")
     );
+    info!("GStreamer {}", gst::version_string());
     info!(
         "Starting at {}",
         chrono::Local::now().format("%Y-%m-%dT%H:%M:%S"),


### PR DESCRIPTION
Initial logs did not include the GStreamer version.

Fix #261