### PR TITLE
fix(stream/manager): recover cooldown flag on error and ensure panic-safe cleanup

### DIFF
--- a/src/lib/stream/manager.rs
+++ b/src/lib/stream/manager.rs
@@ -448,7 +448,7 @@ pub async fn get_jpeg_thumbnail_from_source(
                 if first_request {
                     let cooldown_arc = cooldown.clone();
                     let lifecycle_arc = lifecycle.clone();
-                    std::thread::Builder::new()
+                    let spawn_result = std::thread::Builder::new()
                         .name("ThumbnailCooldown".into())
                         .spawn(move || {
                             loop {
@@ -465,8 +465,16 @@ pub async fn get_jpeg_thumbnail_from_source(
                                     _ => {}
                                 }
                             }
-                        })
-                        .ok();
+                        });
+
+                    if let Err(error) = spawn_result {
+                        warn!("Failed to spawn thumbnail cooldown thread: {error}");
+                        let mut guard = cooldown
+                            .lock()
+                            .unwrap_or_else(std::sync::PoisonError::into_inner);
+                        *guard = None;
+                        lifecycle.remove_consumer_in_background();
+                    }
                 }
 
                 let _ = tx.send(res);

--- a/src/lib/stream/manager.rs
+++ b/src/lib/stream/manager.rs
@@ -356,6 +356,20 @@ pub async fn get_jpeg_thumbnail_from_source(
                     false
                 };
 
+                // Panic-safe guard: if anything panics before the cooldown thread
+                // takes ownership, ensure the consumer is removed and cooldown is reset.
+                let mut consumer_guard = first_request.then(|| {
+                    let lifecycle_bg = lifecycle.clone();
+                    let cooldown_bg = cooldown.clone();
+                    scopeguard::guard((), move |()| {
+                        let mut g = cooldown_bg
+                            .lock()
+                            .unwrap_or_else(std::sync::PoisonError::into_inner);
+                        *g = None;
+                        lifecycle_bg.remove_consumer_in_background();
+                    })
+                });
+
                 // Wait for the pipeline to be alive and Playing.
                 // Truly-idle streams need full Waking (pipeline recreation +
                 // position advance). Draining/Waking/Running streams may
@@ -377,6 +391,9 @@ pub async fn get_jpeg_thumbnail_from_source(
                                         "Failed to remove thumbnail consumer after timeout: {error}"
                                     );
                                 }
+                            }
+                            if let Some(guard) = consumer_guard.take() {
+                                scopeguard::ScopeGuard::into_inner(guard);
                             }
                             let _ = tx.send(Some(Err(Arc::new(anyhow!(
                                 "Pipeline did not resume in time for thumbnail"
@@ -474,6 +491,12 @@ pub async fn get_jpeg_thumbnail_from_source(
                             .unwrap_or_else(std::sync::PoisonError::into_inner);
                         *guard = None;
                         lifecycle.remove_consumer_in_background();
+                    }
+
+                    // Defuse the panic guard — either the cooldown thread has taken
+                    // ownership or we cleaned up on spawn error.
+                    if let Some(guard) = consumer_guard.take() {
+                        scopeguard::ScopeGuard::into_inner(guard);
                     }
                 }
 

--- a/src/lib/stream/manager.rs
+++ b/src/lib/stream/manager.rs
@@ -331,7 +331,9 @@ pub async fn get_jpeg_thumbnail_from_source(
                 // spawn the cooldown cleanup thread later.
                 let first_request;
                 {
-                    let mut guard = cooldown.lock().unwrap();
+                    let mut guard = cooldown
+                        .lock()
+                        .unwrap_or_else(std::sync::PoisonError::into_inner);
                     first_request = guard.is_none();
                     *guard = Some(std::time::Instant::now());
                 }
@@ -383,7 +385,9 @@ pub async fn get_jpeg_thumbnail_from_source(
                             debug!("Pipeline did not resume in time for thumbnail");
                             if first_request {
                                 {
-                                    let mut guard = cooldown.lock().unwrap();
+                                    let mut guard = cooldown
+                                        .lock()
+                                        .unwrap_or_else(std::sync::PoisonError::into_inner);
                                     *guard = None;
                                 }
                                 if let Err(error) = lifecycle.remove_consumer().await {
@@ -470,7 +474,9 @@ pub async fn get_jpeg_thumbnail_from_source(
                         .spawn(move || {
                             loop {
                                 std::thread::sleep(THUMBNAIL_COOLDOWN);
-                                let mut guard = cooldown_arc.lock().unwrap();
+                                let mut guard = cooldown_arc
+                                    .lock()
+                                    .unwrap_or_else(std::sync::PoisonError::into_inner);
                                 match *guard {
                                     Some(last) if last.elapsed() >= THUMBNAIL_COOLDOWN => {
                                         *guard = None;

--- a/src/lib/stream/manager.rs
+++ b/src/lib/stream/manager.rs
@@ -343,6 +343,11 @@ pub async fn get_jpeg_thumbnail_from_source(
                                 && snapshot.consumers == 1
                         }
                         Err(error) => {
+                            // Reset the cooldown flag so subsequent requests are not permanently wedged
+                            let mut guard = cooldown
+                                .lock()
+                                .unwrap_or_else(std::sync::PoisonError::into_inner);
+                            *guard = None;
                             let _ = tx.send(Some(Err(Arc::new(error))));
                             return;
                         }


### PR DESCRIPTION
### What this fixes

1. **Permanent wedging on `add_consumer()` failure**:
   If `lifecycle.add_consumer().await` failed on an initial thumbnail request, `thumbnail_cooldown` was left set to `Some(...)`. Every subsequent request skipped waking the stream and timed out after 30 seconds indefinitely.
   - **Fix**: Reset `thumbnail_cooldown` to `None` on error so future requests can retry.

2. **Panic-safe cleanup**:
   If a panic occurred before the cooldown thread took ownership, the consumer was never removed, permanently pinning the stream active.
   - **Fix**: Added a `scopeguard` (already in workspace from `sink/mod.rs`) to guarantee consumer removal and cooldown reset on panic.

3. **Thread spawn error & poison resilience**:
   - If `thread::spawn` fails under thread exhaustion, cleanup runs immediately instead of leaking the consumer via `.ok()`.
   - Handled poisoned mutex locks safely with `unwrap_or_else(PoisonError::into_inner)`.

### Architecture Note
- Dedicated OS thread + Tokio runtime isolation for GStreamer thumbnails remains fully intact.
