### PR TITLE
docs: fix typos in comments, log messages, error strings, and README

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,7 +61,7 @@ Download the mavlink-camera-manager binary for your architecture from our [relea
 ### 2. Installing:
 
 _note: We recommend GStreamer `1.24.0` or above. Previous versions have thread leaks when using WebRTC. You can check it by running `gst-launch-1.0 --version`. If the required version is not available on your operating system from their official store, follow the recommendations from [here](https://gstreamer.freedesktop.org/download)_
-_note 2: for a docker-based installation, use can use [this folder](master/docker) as an example_
+_note 2: for a docker-based installation, you can use [this folder](master/docker) as an example_
 
 **Linux (Ubuntu-based distros)**
 
@@ -224,7 +224,7 @@ This project is licensed under the [MIT License](/LICENSE).
 
 ## Project origins
 
-The Mavlink Camera Manager project originated as a personal experiment by [@patrickelectric](github.com/patrickelectric/), driven by the need to address a critical challenge in remotely operated vehicles – effectively managing and providing camera streams to the topside computer. At the time, there was a noticeable absence of open-source alternatives, which motivated the project's inception.
+The Mavlink Camera Manager project originated as a personal experiment by [@patrickelectric](https://github.com/patrickelectric/), driven by the need to address a critical challenge in remotely operated vehicles – effectively managing and providing camera streams to the topside computer. At the time, there was a noticeable absence of open-source alternatives, which motivated the project's inception.
 
 Over time, the project gained recognition and was officially embraced by [**Blue Robotics**](https://github.com/bluerobotics) as a core development effort. It became an integral part of their operating system, BlueOS, and was widely distributed worldwide. The adoption of the Mavlink Camera Manager by Blue Robotics served as a testament to its capabilities and value.
 

--- a/src/lib/stream/gst/utils.rs
+++ b/src/lib/stream/gst/utils.rs
@@ -163,7 +163,7 @@ pub fn set_plugin_rank(plugin_name: &str, rank: gst::Rank) -> Result<()> {
         feature.set_rank(rank);
     } else {
         return Err(anyhow!(
-            "Cannot found Gstreamer feature {plugin_name:#?} in the registry.",
+            "Cannot find GStreamer feature {plugin_name:#?} in the registry.",
         ));
     }
 

--- a/src/lib/stream/mod.rs
+++ b/src/lib/stream/mod.rs
@@ -1084,7 +1084,7 @@ fn validate_endpoints(video_and_stream_information: &VideoAndStreamInformation) 
             }
             "udp265" => {
                 if VideoEncodeType::H265 != encode {
-                    return Some(anyhow!("Endpoint with udp265 scheme only supports H265 encode. Encode: {encode:?}, Endpoint: {endpoints:?}"));
+                    return Some(anyhow!("Endpoint with udp265 scheme only supports H265 encode. Encode: {encode:?}, Endpoint: {endpoint:?}"));
                 }
             }
             _ => {

--- a/src/lib/stream/pipeline/mod.rs
+++ b/src/lib/stream/pipeline/mod.rs
@@ -275,13 +275,13 @@ impl PipelineState {
             }
         }
 
-        // Skipping ImageSink syncronization because it goes to some wrong state,
+        // Skipping ImageSink synchronization because it goes to some wrong state,
         // and all other sinks need it to work without freezing when dynamically
         // added.
         if !matches!(&sink, Sink::Image(..))
             && let Err(error) = pipeline.sync_children_states()
         {
-            error!("Failed to syncronize children states. Reason: {error:?}");
+            error!("Failed to synchronize children states. Reason: {error:?}");
         }
 
         // Start the sink's own sub-pipeline runner

--- a/src/lib/stream/pipeline/runner.rs
+++ b/src/lib/stream/pipeline/runner.rs
@@ -183,7 +183,7 @@ impl PipelineRunner {
                             } else {
                                 let priority = thread_priority::get_current_thread_priority();
                                 let scheduler = thread_priority::get_thread_scheduling_attributes();
-                                info!("GStreamer stream thread sucessfully configured to MAX priority ({priority:?}) and real-time round robyn ({scheduler:?}). From element {:?}, from Pipeline {pipeline_name:?}", element.name());
+                                info!("GStreamer stream thread successfully configured to MAX priority ({priority:?}) and real-time round robin ({scheduler:?}). From element {:?}, from Pipeline {pipeline_name:?}", element.name());
                             }
                         } else {
                             crate::helper::threads::lower_to_background_priority();


### PR DESCRIPTION
## Summary
Small typo/grammar fixes across docs, logs, and error strings. No logic changes.

- `README.md`: `use can use` -> `you can use`; fixed GitHub link format
- `pipeline/mod.rs`: `syncronization` -> `synchronization` (comment + log)
- `pipeline/runner.rs`: `sucessfully` -> `successfully`; `round robyn` -> `round robin`
- `gst/utils.rs`: `Cannot found Gstreamer feature` -> `Cannot find GStreamer feature`
- `stream/mod.rs`: fixed wrong variable in error message (`endpoints` -> `endpoint`)
