### PR TITLE
video: gst_device_monitor: Add USB id lookup

### DIFF
--- a/frontend/src/home/HomeView.vue
+++ b/frontend/src/home/HomeView.vue
@@ -7,6 +7,7 @@
         </div>
         <div>
           <p>Device: {{ item.source }}</p>
+          <p v-if="item.usb_id">USB ID: {{ item.usb_id }}</p>
         </div>
         <h4>Configure Stream:</h4>
         <div>

--- a/src/lib/server/pages.rs
+++ b/src/lib/server/pages.rs
@@ -20,6 +20,7 @@ use crate::{
     settings,
     stream::{gst as gst_stream, manager as stream_manager, types::StreamInformation},
     video::{
+        gst_device_monitor,
         types::{Format, VideoSourceType},
         video_source::{self, VideoSource, VideoSourceFormats},
         xml,
@@ -34,6 +35,8 @@ pub struct ApiVideoSource {
     formats: Vec<Format>,
     controls: Vec<Control>,
     blocked: bool,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    usb_id: Option<String>,
 }
 
 #[derive(Apiv2Schema, Debug, Deserialize, Serialize)]
@@ -221,6 +224,7 @@ pub async fn v4l() -> Result<Json<Vec<ApiVideoSource>>> {
                         formats: local.formats().await,
                         controls: local.controls(),
                         blocked,
+                        usb_id: gst_device_monitor::usb_id(local.source_string()),
                     },
                     VideoSourceType::Gst(gst) => ApiVideoSource {
                         name: gst.name().clone(),
@@ -228,6 +232,7 @@ pub async fn v4l() -> Result<Json<Vec<ApiVideoSource>>> {
                         formats: gst.formats().await,
                         controls: gst.controls(),
                         blocked,
+                        usb_id: None,
                     },
                     VideoSourceType::Onvif(onvif) => ApiVideoSource {
                         name: onvif.name().clone(),
@@ -235,6 +240,7 @@ pub async fn v4l() -> Result<Json<Vec<ApiVideoSource>>> {
                         formats: onvif.formats().await,
                         controls: onvif.controls(),
                         blocked,
+                        usb_id: None,
                     },
                     VideoSourceType::Redirect(redirect) => ApiVideoSource {
                         name: redirect.name().clone(),
@@ -242,6 +248,7 @@ pub async fn v4l() -> Result<Json<Vec<ApiVideoSource>>> {
                         formats: redirect.formats().await,
                         controls: redirect.controls(),
                         blocked,
+                        usb_id: None,
                     },
                 }
             }

--- a/src/lib/video/gst_device_monitor.rs
+++ b/src/lib/video/gst_device_monitor.rs
@@ -111,6 +111,15 @@ pub fn v4l_device_with_path(device_path: &str) -> Result<glib::WeakRef<gst::Devi
 }
 
 #[instrument(level = "debug")]
+pub fn usb_id(device_path: &str) -> Option<String> {
+    let device = v4l_device_with_path(device_path).ok()?.upgrade()?;
+    let properties = device.properties()?;
+    let vendor = properties.get::<String>("device.vendor.id").ok()?;
+    let product = properties.get::<String>("device.product.id").ok()?;
+    Some(format!("{vendor}:{product}"))
+}
+
+#[instrument(level = "debug")]
 pub fn device_caps(device: &glib::WeakRef<gst::Device>) -> Result<gst::Caps> {
     device
         .upgrade()


### PR DESCRIPTION
GStreamer already has device.vendor.id / device.product.id, /v4l was not returning them.

Fix #248