### PR TITLE
lib: logger: manager: Add cargo dependencies log

### DIFF
--- a/src/lib/logger/manager.rs
+++ b/src/lib/logger/manager.rs
@@ -199,6 +199,10 @@ pub fn init() {
     );
     info!("GStreamer {}", gst::version_string());
     info!(
+        "Build dependencies details: {}",
+        env!("VERGEN_CARGO_DEPENDENCIES"),
+    );
+    info!(
         "Starting at {}",
         chrono::Local::now().format("%Y-%m-%dT%H:%M:%S"),
     );


### PR DESCRIPTION
vergen already emit the crate list, we never log it.