### PR TITLE
Simplify single-stream device updates

### DIFF
--- a/src/lib/stream/manager.rs
+++ b/src/lib/stream/manager.rs
@@ -145,67 +145,76 @@ pub async fn update_devices(
     verbose: bool,
 ) {
     for stream in streams {
-        let VideoSourceType::Local(source) = &mut stream.video_source else {
-            continue;
-        };
-        let CaptureConfiguration::Video(capture_configuration) =
-            &stream.stream_information.configuration
-        else {
-            continue;
-        };
+        update_device(stream, candidates, verbose).await;
+    }
+}
 
-        // Only resolve formats for candidates sharing the source name so that mismatched
-        // candidates (which are filtered out by name first) don't trigger device probing.
-        let mut formats: HashMap<String, Vec<Format>> = HashMap::new();
-        for candidate in candidates.iter() {
-            let VideoSourceType::Local(camera) = candidate else {
-                continue;
+#[instrument(level = "debug")]
+pub(super) async fn update_device(
+    stream: &mut VideoAndStreamInformation,
+    candidates: &mut Vec<VideoSourceType>,
+    verbose: bool,
+) {
+    let VideoSourceType::Local(source) = &mut stream.video_source else {
+        return;
+    };
+    let CaptureConfiguration::Video(capture_configuration) =
+        &stream.stream_information.configuration
+    else {
+        return;
+    };
+
+    // Only resolve formats for candidates sharing the source name so that mismatched
+    // candidates (which are filtered out by name first) don't trigger device probing.
+    let mut formats: HashMap<String, Vec<Format>> = HashMap::new();
+    for candidate in candidates.iter() {
+        let VideoSourceType::Local(camera) = candidate else {
+            continue;
+        };
+        if camera.name != source.name {
+            continue;
+        }
+        formats.insert(
+            candidate.inner().source_string().to_string(),
+            candidate.formats().await,
+        );
+    }
+
+    match source
+        .try_identify_device(capture_configuration, candidates, &formats)
+        .await
+    {
+        Ok(Some(candidate_source_string)) => {
+            let Some((idx, candidate)) =
+                candidates.iter().enumerate().find_map(|(idx, candidate)| {
+                    (candidate.inner().source_string() == candidate_source_string)
+                        .then_some((idx, candidate))
+                })
+            else {
+                error!(
+                    "CRITICAL: The device was identified as {candidate_source_string:?}, but it is not the candidates list"
+                ); // This shouldn't ever be reachable, otherwise the above logic is flawed
+                return;
             };
-            if camera.name != source.name {
-                continue;
-            }
-            formats.insert(
-                candidate.inner().source_string().to_string(),
-                candidate.formats().await,
-            );
-        }
 
-        match source
-            .try_identify_device(capture_configuration, candidates, &formats)
-            .await
-        {
-            Ok(Some(candidate_source_string)) => {
-                let Some((idx, candidate)) =
-                    candidates.iter().enumerate().find_map(|(idx, candidate)| {
-                        (candidate.inner().source_string() == candidate_source_string)
-                            .then_some((idx, candidate))
-                    })
-                else {
-                    error!(
-                        "CRITICAL: The device was identified as {candidate_source_string:?}, but it is not the candidates list"
-                    ); // This shouldn't ever be reachable, otherwise the above logic is flawed
-                    continue;
-                };
-
-                let VideoSourceType::Local(camera) = candidate else {
-                    error!(
-                        "CRITICAL: The device was identified as {candidate_source_string:?}, but it is not a Local device"
-                    ); // This shouldn't ever be reachable, otherwise the above logic is flawed
-                    continue;
-                };
-                *source = camera.clone();
-                // Only remove the candidate from the list after using it, avoiding the wrong but possible logic from the CRITICAL erros branches above, the additional cost is this clone
-                candidates.remove(idx);
-            }
-            Err(reason) => {
-                // Invalidate the device
-                source.device_path = "".into();
-                if verbose {
-                    warn!("Device {source:?} was invalidated. Reason: {reason:?}");
-                };
-            }
-            _ => (),
+            let VideoSourceType::Local(camera) = candidate else {
+                error!(
+                    "CRITICAL: The device was identified as {candidate_source_string:?}, but it is not a Local device"
+                ); // This shouldn't ever be reachable, otherwise the above logic is flawed
+                return;
+            };
+            *source = camera.clone();
+            // Only remove the candidate from the list after using it, avoiding the wrong but possible logic from the CRITICAL erros branches above, the additional cost is this clone
+            candidates.remove(idx);
         }
+        Err(reason) => {
+            // Invalidate the device
+            source.device_path = "".into();
+            if verbose {
+                warn!("Device {source:?} was invalidated. Reason: {reason:?}");
+            };
+        }
+        _ => (),
     }
 }
 

--- a/src/lib/stream/mod.rs
+++ b/src/lib/stream/mod.rs
@@ -381,7 +381,7 @@ impl Stream {
                         video_and_stream_information_cloned.video_source,
                         VideoSourceType::Local(_)
                     ) {
-                        let mut streams = vec![video_and_stream_information_cloned.clone()];
+                        let mut updated_stream = video_and_stream_information_cloned.clone();
                         let mut candidates = cameras_available().await;
 
                         // Discards any source from other running streams, otherwise we'd be trying to create a stream from a device in use (which is not possible)
@@ -405,8 +405,8 @@ impl Stream {
                             std::time::Instant::now() - last_report_time >= report_interval;
 
                         // Find the best candidate
-                        manager::update_devices(&mut streams, &mut candidates, should_report).await;
-                        let updated_stream = streams.first().unwrap();
+                        manager::update_device(&mut updated_stream, &mut candidates, should_report)
+                            .await;
                         *video_and_stream_information.write().await = updated_stream.clone();
 
                         // Check if the chosen video source is available
@@ -1524,8 +1524,8 @@ mod tests {
 
     #[cfg(target_os = "linux")]
     #[tokio::test]
-    async fn update_devices_invalidates_device_when_no_candidates_match() {
-        let mut streams = vec![VideoAndStreamInformation {
+    async fn update_device_invalidates_device_when_no_candidates_match() {
+        let mut stream = VideoAndStreamInformation {
             name: "test-local".into(),
             stream_information: test_stream_information(),
             video_source: VideoSourceType::Local(VideoSourceLocal {
@@ -1533,13 +1533,13 @@ mod tests {
                 device_path: "/dev/video99".into(),
                 typ: VideoSourceLocalType::Unknown("test".into()),
             }),
-        }];
+        };
 
         let mut candidates = vec![];
 
-        manager::update_devices(&mut streams, &mut candidates, false).await;
+        manager::update_device(&mut stream, &mut candidates, false).await;
 
-        let VideoSourceType::Local(source) = &streams[0].video_source else {
+        let VideoSourceType::Local(source) = &stream.video_source else {
             panic!("expected Local source");
         };
         assert_eq!(
@@ -1550,8 +1550,8 @@ mod tests {
 
     #[cfg(target_os = "linux")]
     #[tokio::test]
-    async fn update_devices_picks_candidate_with_same_name_and_encode() {
-        let mut streams = vec![VideoAndStreamInformation {
+    async fn update_device_picks_candidate_with_same_name_and_encode() {
+        let mut stream = VideoAndStreamInformation {
             name: "test-local".into(),
             stream_information: StreamInformation {
                 endpoints: vec![Url::parse("rtsp://127.0.0.1:8554/test").unwrap()],
@@ -1571,7 +1571,7 @@ mod tests {
                 device_path: "/dev/video0".into(),
                 typ: VideoSourceLocalType::Usb("0000:00:14.0-2".into()),
             }),
-        }];
+        };
 
         let mut candidates = vec![VideoSourceType::Local(VideoSourceLocal {
             name: "Different Camera".into(),
@@ -1579,9 +1579,9 @@ mod tests {
             typ: VideoSourceLocalType::Usb("0000:00:14.0-3".into()),
         })];
 
-        manager::update_devices(&mut streams, &mut candidates, false).await;
+        manager::update_device(&mut stream, &mut candidates, false).await;
 
-        let VideoSourceType::Local(source) = &streams[0].video_source else {
+        let VideoSourceType::Local(source) = &stream.video_source else {
             panic!("expected Local source");
         };
         assert_eq!(


### PR DESCRIPTION
## Summary

- extract a single-stream `update_device` helper from the existing batch updater
- update the device watcher without constructing a one-element stream vector
- retain `update_devices` for callers that genuinely update multiple streams
- adapt the focused device-selection tests to exercise the single-stream path

Closes #599. This implements the simplification identified in the review of #596.

## Verification

- `cargo fmt --all -- --check`
- `git diff --check`
- `cargo test --lib` was attempted, but this environment does not provide the system `gstreamer-1.0` development package required by `gstreamer-sys`

## Evidence

Before: issue #599 documenting the unnecessary one-element collections in the watcher:

![Issue and requested simplification](https://github.com/user-attachments/assets/5e71e026-207f-41d9-93b2-f2627fbebaf1)

After: the public contribution commit showing the focused implementation and tests:

![Implementation after the refactor](https://github.com/user-attachments/assets/b79e5880-3b04-41ae-817f-f03a7a5cb515)
